### PR TITLE
Updated the hyperlink for "Retrieval with FastEmbed"

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ FastEmbed is an easy to use -- lightweight, fast, Python library built for retri
 
 The default embedding supports "query" and "passage" prefixes for the input text. The default model is [Flag Embedding](https://github.com/FlagOpen/FlagEmbedding), which is top of the [MTEB](https://huggingface.co/spaces/mteb/leaderboard) leaderboard. 
 
-Advanced user? Skip ahead to [Retrieval with FastEmbed](https://qdrant.github.io/fastembed/examples/Retrieval%20with%20FastEmbed/)
+Advanced user? Skip ahead to [Retrieval with FastEmbed](https://qdrant.github.io/fastembed/examples/Retrieval_with_FastEmbed/)
 
 To install the FastEmbed library, pip works: 
 


### PR DESCRIPTION
prev -: https://qdrant.github.io/fastembed/examples/Retrieval%20with%20FastEmbed/

now -: https://qdrant.github.io/fastembed/examples/Retrieval_with_FastEmbed/