### PR TITLE
* docs(examples): update FastEmbed_vs_HF_Comparison.ipynb

### DIFF
--- a/docs/examples/FastEmbed_vs_HF_Comparison.ipynb
+++ b/docs/examples/FastEmbed_vs_HF_Comparison.ipynb
@@ -296,7 +296,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This indicates the embeddings are quite close to each with a cosine similarity of 0.99. This gives us confidence that the embeddings are the same and we are not sacrificing accuracy for speed."
+    "This indicates the embeddings are quite close to each with a cosine similarity of 0.99 for BAAI/bge-small-en and 0.92 for BAAI/bge-small-en-v1.5. This gives us confidence that the embeddings are the same and we are not sacrificing accuracy for speed."
    ]
   }
  ],


### PR DESCRIPTION
with cosine similarity values for BAAI/bge-small-en and BAAI/bge-small-en-v1.5 embeddings