### PR TITLE
feat: Added support for FASTEMBED_CACHE_PATH env var

### DIFF
--- a/fastembed/embedding.py
+++ b/fastembed/embedding.py
@@ -2,6 +2,8 @@ import json
 import os
 import shutil
 import tarfile
+import tempfile
+
 from abc import ABC, abstractmethod
 from itertools import islice
 from multiprocessing import get_all_start_methods
@@ -461,7 +463,7 @@ class FlagEmbedding(Embedding):
             max_length (int, optional): The maximum number of tokens. Defaults to 512. Unknown behavior for values > 512.
             cache_dir (str, optional): The path to the cache directory.
                                        Can be set using the `FASTEMBED_CACHE_PATH` env variable.
-                                       Defaults to `local_cache` in the current directory.
+                                       Defaults to `fastembed_cache` in the system's temp directory.
             threads (int, optional): The number of threads single onnxruntime session can use. Defaults to None.
 
         Raises:
@@ -470,7 +472,7 @@ class FlagEmbedding(Embedding):
         self.model_name = model_name
 
         if cache_dir is None:
-            default_cache_dir = Path(".").resolve() / "local_cache"
+            default_cache_dir = os.path.join(tempfile.gettempdir(), "fastembed_cache")
             cache_dir = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
             cache_dir.mkdir(parents=True, exist_ok=True)
 
@@ -581,7 +583,7 @@ class JinaEmbedding(Embedding):
             max_length (int, optional): The maximum number of tokens. Defaults to 512. Unknown behavior for values > 512.
             cache_dir (str, optional): The path to the cache directory.
                                        Can be set using the `FASTEMBED_CACHE_PATH` env variable.
-                                       Defaults to `local_cache` in the current directory.
+                                       Defaults to `fastembed_cache` in the system's temp directory.
             threads (int, optional): The number of threads single onnxruntime session can use. Defaults to None.
         Raises:
             ValueError: If the model_name is not in the format <org>/<model> e.g. BAAI/bge-base-en.
@@ -590,7 +592,7 @@ class JinaEmbedding(Embedding):
 
         if cache_dir is None:
             default_cache_dir = Path(".").resolve() / "local_cache"
-            cache_dir = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
+            cache_dir = default_cache_dir = os.path.join(tempfile.gettempdir(), "fastembed_cache")
             cache_dir.mkdir(parents=True, exist_ok=True)
 
         self._cache_dir = cache_dir

--- a/fastembed/embedding.py
+++ b/fastembed/embedding.py
@@ -459,7 +459,9 @@ class FlagEmbedding(Embedding):
         Args:
             model_name (str): The name of the model to use.
             max_length (int, optional): The maximum number of tokens. Defaults to 512. Unknown behavior for values > 512.
-            cache_dir (str, optional): The path to the cache directory. Defaults to `local_cache` in the current directory.
+            cache_dir (str, optional): The path to the cache directory.
+                                       Can be set using the `FASTEMBED_CACHE_PATH` env variable.
+                                       Defaults to `local_cache` in the current directory.
             threads (int, optional): The number of threads single onnxruntime session can use. Defaults to None.
 
         Raises:
@@ -468,7 +470,8 @@ class FlagEmbedding(Embedding):
         self.model_name = model_name
 
         if cache_dir is None:
-            cache_dir = Path(".").resolve() / "local_cache"
+            default_cache_dir = Path(".").resolve() / "local_cache"
+            cache_dir = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
             cache_dir.mkdir(parents=True, exist_ok=True)
 
         self._cache_dir = cache_dir
@@ -576,7 +579,9 @@ class JinaEmbedding(Embedding):
         Args:
             model_name (str): The name of the model to use.
             max_length (int, optional): The maximum number of tokens. Defaults to 512. Unknown behavior for values > 512.
-            cache_dir (str, optional): The path to the cache directory. Defaults to `local_cache` in the current directory.
+            cache_dir (str, optional): The path to the cache directory.
+                                       Can be set using the `FASTEMBED_CACHE_PATH` env variable.
+                                       Defaults to `local_cache` in the current directory.
             threads (int, optional): The number of threads single onnxruntime session can use. Defaults to None.
         Raises:
             ValueError: If the model_name is not in the format <org>/<model> e.g. BAAI/bge-base-en.
@@ -584,7 +589,8 @@ class JinaEmbedding(Embedding):
         self.model_name = model_name
 
         if cache_dir is None:
-            cache_dir = Path(".").resolve() / "local_cache"
+            default_cache_dir = Path(".").resolve() / "local_cache"
+            cache_dir = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
             cache_dir.mkdir(parents=True, exist_ok=True)
 
         self._cache_dir = cache_dir

--- a/fastembed/embedding.py
+++ b/fastembed/embedding.py
@@ -591,8 +591,8 @@ class JinaEmbedding(Embedding):
         self.model_name = model_name
 
         if cache_dir is None:
-            default_cache_dir = Path(".").resolve() / "local_cache"
-            cache_dir = default_cache_dir = os.path.join(tempfile.gettempdir(), "fastembed_cache")
+            default_cache_dir = os.path.join(tempfile.gettempdir(), "fastembed_cache")
+            cache_dir = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
             cache_dir.mkdir(parents=True, exist_ok=True)
 
         self._cache_dir = cache_dir


### PR DESCRIPTION
- Adds support for the `FASTEMBED_CACHE_PATH` env var. ed318328003532f02764885697766f510c686de2.
- Pre-commit formatting changes. d0e9f35f808b990d7d032acd9d954f85f9510308

Resolves #50.
