### PR TITLE
Check for existing files in cache dir before instantiating a model

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -131,7 +131,7 @@ class ModelManagement:
         model_tmp_dir = cache_tmp_dir / fast_model_name
         model_dir = Path(cache_dir) / fast_model_name
 
-        if model_dir.exists():
+        if model_dir.exists() and len(list(model_dir.glob("*"))) > 0:
             return model_dir
 
         if model_tmp_dir.exists():


### PR DESCRIPTION
This is directly related to issue #127 

macOS seems to flag temp files as up for deletion [after about 3 days](https://apple.stackexchange.com/a/404401). This was causing issues with the model cache dir existing, but the model files themselves not.

Let me know if you guys have a better idea for this, or an entirely different approach!

