### PR TITLE
Fix link to Optimum in docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The default embedding supports "query" and "passage" prefixes for the input text
 
 1. Light & Fast
     - Quantized model weights
-    - ONNX Runtime for inference via [Optimum](github.com/huggingface/optimum)
+    - ONNX Runtime for inference via [Optimum](https://github.com/huggingface/optimum)
 
 2. Accuracy/Recall
     - Better than OpenAI Ada-002


### PR DESCRIPTION
Just fixing the link. Feel free to close the PR, if you would rather make the change yourself.

![image](https://github.com/qdrant/fastembed/assets/3200920/5f545d9d-43fb-4352-9200-2ecc5acd790f)
