### PR TITLE
Add import statement for version debugging

### DIFF
--- a/fastembed/__init__.py
+++ b/fastembed/__init__.py
@@ -1,3 +1,6 @@
+import importlib.metadata
+
 from fastembed.text.text_embedding import TextEmbedding
 
+__version__ = importlib.metadata.version("fastembed")
 __all__ = ["TextEmbedding"]


### PR DESCRIPTION
This allows user to use something like this to report the FastEmbed version with their bug reports:

```bash
python -c "import fastembed; print(fastembed.__version__)
```