### PR TITLE
Add Support for intfloat/multilingual-e5-large-instruct :Fixes #140 

### DIFF
--- a/docs/examples/Supported_Models.ipynb
+++ b/docs/examples/Supported_Models.ipynb
@@ -184,7 +184,7 @@
        "      <td> intfloat/multilingual-e5-large-instruct </td>\n",
        "      <td>1024</td>\n",
        "      <td>Multilingual model, e5-large-instruct</td>\n",
-       "      <td>1.03</td>\n",
+       "      <td>1.120</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -227,7 +227,7 @@
        "13                          Large English model, v1.5       1.200  \n",
        "14                Large general text embeddings model       1.200  \n",
        "15  Multilingual model, e5-large. Recommend using ...       2.240  \n",
-       "16  Multilingual model, e5-large-instruct.                  1.03    "
+       "16  Multilingual model, e5-large-instruct.                  1.120    "
       ]
      },
      "execution_count": 6,

--- a/fastembed/text/e5_onnx_embedding.py
+++ b/fastembed/text/e5_onnx_embedding.py
@@ -25,6 +25,15 @@ supported_multilingual_e5_models = [
             "hf": "xenova/paraphrase-multilingual-mpnet-base-v2",
         },
     },
+    {
+        "model": "intfloat/multilingual-e5-large-instruct",
+        "dim": 1024,
+        "description": "multilingual model, e5-large-instruct",
+        "size_in_GB": 1.12,
+        "sources": {
+            "hf": "yashvardhan7/multilingual-e5-large-instruct",
+        },
+    },
 ]
 
 

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -28,6 +28,7 @@ CANONICAL_VECTOR_VALUES = {
     ),
     "thenlper/gte-large": np.array([-0.01920587, 0.00113156, -0.00708992, -0.00632304, -0.04025577]),
     "mixedbread-ai/mxbai-embed-large-v1": np.array([0.02295546, 0.03196154, 0.016512, -0.04031524, -0.0219634]),
+    "intfloat/multilingual-e5-large-instruct": np.array([ 0.01020065,  0.0236722,   0.00117698, -0.04327101,  0.02887568]),
 }
 
 


### PR DESCRIPTION
## Description:
This pull request addresses issue #140 by integrating the intfloat/multilingual-e5-large-instruct model from [Hugging Face](https://huggingface.co/intfloat/multilingual-e5-large-instruct) into the repo. This update extends capabilities, enabling it to support more diverse language embeddings and accommodate various numerical data types seamlessly.

### Changes:

•Model Support: The intfloat/multilingual-e5-large-instruct model is now supported, expanding our project's multilingual 
processing capabilities.

•Documentation Update: Updated the Supported_Models.ipynb notebook to include documentation and usage examples for the new model.

•Configuration Update: Modified e5_onnx_embedding.py to include configuration settings specific to the intfloat/multilingual-e5-large-instruct model, ensuring optimal performance.

•Testing: Enhanced test_text_onnx_embeddings.py with new test cases designed to validate the output embeddings of the intfloat/multilingual-e5-large-instruct model against predefined documents.

•CANONICAL_VECTOR values : Here is a reference [Colab Notebook](https://colab.research.google.com/drive/1JQXyw4b23zYoWNWF3YdhQKVrI89Jqtol?usp=sharing)


### Onnx file :


HuggingFaceHub:
https://huggingface.co/yashvardhan7/multilingual-e5-large-instruct/tree/main

### Test:

 All test cases have successfully passed with the inclusion of the latest intfloat/multilingual-e5-large-instruct model.
