### PR TITLE
Workaround for running on SLURM

### DIFF
--- a/fastembed/common/onnx_model.py
+++ b/fastembed/common/onnx_model.py
@@ -41,6 +41,9 @@ class OnnxModel(Generic[T]):
         onnx_providers = ["CPUExecutionProvider"]
 
         so = ort.SessionOptions()
+        if os.getenv("SLURM_JOB_ID") != "":
+            so.intra_op_num_threads = os.getenv("SLURM_CPUS_ON_NODE")
+            so.inter_op_num_threads = os.getenv("SLURM_CPUS_ON_NODE")
         so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
 
         if threads is not None:


### PR DESCRIPTION
At present, fastembed throws a cryptic error about CPU affinity when running on a SLURM cluster, which I tracked down to onnxruntime. This means it is impossible to use fastembed while running on SLURM. Updating versions of everything to their latest does not help. 

onnxruntime would usually get the number of threads from OMP_NUM_THREADS (I think), but that isn't set on SLURM which handles the number of threads differently.

This addition tries to figure out if we're running under SLURM, and if so sets the session options accordingly using SLURM environment variables instead. I've been assured that SURM in general disables hyperthreading, so the number of CPUs on node should be the same as the number of threads available. One thing I'm not 100% sure about is if setting `intra_op_num_threads` and `inter_op_num_threads` to the maximum allowable number is a good idea. I got decent throughput on a node with 12 CPUs, so I think it is fine.

Tested working with latest versions of onnxruntime (1.17.3) and fastembed (0.2.6) with python 3.10.10 on slurm 23.02.07