### PR TITLE
refactoring: refactor model downloading

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -98,7 +98,7 @@ class ModelManagement:
             hf_source_repo (str): Name of the model on HuggingFace Hub, e.g. "qdrant/all-MiniLM-L6-v2-onnx".
             cache_dir (Optional[str]): The path to the cache directory.
             extra_patterns (Optional[List[str]]): extra patterns to allow in the snapshot download, typically
-                includes the model's name and additional .onnx files
+                includes the required model files.
         Returns:
             Path: The path to the model directory.
         """

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -78,18 +78,16 @@ class SpladePP(SparseTextEmbeddingBase, OnnxModel[SparseEmbedding]):
         """
 
         super().__init__(model_name, cache_dir, threads, **kwargs)
-        
+
         model_description = self._get_model_description(model_name)
         cache_dir = define_cache_dir(cache_dir)
 
-        model_dir, source = self.download_repo_files(model_description, cache_dir)
+        model_dir = self.download_model(model_description, cache_dir)
 
         self.load_onnx_model(
-            model_dir,
-            threads,
-            cache_dir,
-            model_description,
-            source,
+            model_dir=model_dir,
+            model_file=model_description["model_file"],
+            threads=threads,
         )
 
     def embed(

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -179,15 +179,12 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxModel[np.ndarray]):
 
         model_description = self._get_model_description(model_name)
         cache_dir = define_cache_dir(cache_dir)
-
-        model_dir, source = self.download_repo_files(model_description, cache_dir)
+        model_dir = self.download_model(model_description, cache_dir)
 
         self.load_onnx_model(
-            model_dir,
-            threads,
-            cache_dir,
-            model_description,
-            source,
+            model_dir=model_dir,
+            model_file=model_description["model_file"],
+            threads=threads,
         )
 
     def embed(


### PR DESCRIPTION
This PR brings back model downloading to a single place (`download_model`)

I think it is better to keep all the download logic in `ModelManagement`, and make `load_onnx_model` have only one responsibility - load a model into ram