### PR TITLE
ci: Schedule python-tests.yml

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -43,13 +43,13 @@ jobs:
           poetry install --no-interaction --no-ansi --without docs
 
       - name: Install Test Dependencies
-        run: pip install pytest pytest-md
+        run: pip install pytest pytest-md pytest-emoji
 
       - name: Run pytest
         uses: pavelzw/pytest-action@v2
         with:
             verbose: true
-            emoji: false
+            emoji: true
             job-summary: true
             custom-arguments: '-q'
             click-to-expand: true

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -51,6 +51,4 @@ jobs:
             verbose: true
             emoji: true
             job-summary: true
-            custom-arguments: '-q'
-            click-to-expand: true
             report-title: 'FastEmbed Test Report'

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -31,9 +31,9 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} test
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -3,6 +3,8 @@ name: Tests
 on:
   push:
     branches: [ master, main ]
+  schedule:
+    - cron: 0 0 * * *
   pull_request:
 
 env:
@@ -39,8 +41,16 @@ jobs:
           python -m pip install poetry
           poetry config virtualenvs.create false
           poetry install --no-interaction --no-ansi --without docs
-      - name: Run tests
-        run: |
-          export IS_UBUNTU_CI=$(test "${{ matrix.os }}" = "ubuntu-latest" && echo "true" || echo "false")
-          pytest
-        shell: bash
+
+      - name: Install Test Dependencies
+        run: pip install pytest pytest-md
+
+      - name: Run pytest
+        uses: pavelzw/pytest-action@v2
+        with:
+            verbose: true
+            emoji: false
+            job-summary: true
+            custom-arguments: '-q'
+            click-to-expand: true
+            report-title: 'FastEmbed Test Report'

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -39,10 +39,10 @@ CANONICAL_VECTOR_VALUES = {
 
 
 def test_embedding():
-    is_ubuntu_ci = os.getenv("IS_UBUNTU_CI")
+    is_ci = os.getenv("CI")
 
     for model_desc in TextEmbedding.list_supported_models():
-        if is_ubuntu_ci == "false" and model_desc["size_in_GB"] > 1:
+        if not is_ci and model_desc["size_in_GB"] > 1:
             continue
 
         dim = model_desc["dim"]


### PR DESCRIPTION
Schedule the integration tests to run every day at 00:00 with test reports.

P.S. Bumps some GH Actions, since one of them uses Node@12, which is deprecated.