### PR TITLE
new: remove slurm environment variables

### DIFF
--- a/fastembed/common/onnx_model.py
+++ b/fastembed/common/onnx_model.py
@@ -46,9 +46,6 @@ class OnnxModel(Generic[T]):
         onnx_providers = ["CPUExecutionProvider"]
 
         so = ort.SessionOptions()
-        if os.getenv("SLURM_JOB_ID") is not None:
-            so.intra_op_num_threads = int(os.getenv("SLURM_CPUS_ON_NODE"))
-            so.inter_op_num_threads = int(os.getenv("SLURM_CPUS_ON_NODE"))
         so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
 
         if threads is not None:


### PR DESCRIPTION
After a discussion with @generall , it has been decided to remove slurm environment variables.
The reason is that we do workarounds for the projects, which are not directly related to fastembed, which is not a good practice for maintaining the project clean. 
We might introduce a way to handle setting the number of threads for onnx in the further releases.

cc: @afg1   