### PR TITLE
[Bugfix] Allow user to pick local mode only so huggingface does not do a network call and timeout

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -91,6 +91,7 @@ class ModelManagement:
         hf_source_repo: str,
         cache_dir: Optional[str] = None,
         extra_patterns: Optional[List[str]] = None,
+        **kwargs
     ) -> str:
         """
         Downloads a model from HuggingFace Hub.
@@ -115,6 +116,7 @@ class ModelManagement:
             repo_id=hf_source_repo,
             allow_patterns=allow_patterns,
             cache_dir=cache_dir,
+            local_files_only=kwargs.get('local_files_only', False)
         )
 
     @classmethod
@@ -189,7 +191,7 @@ class ModelManagement:
         return model_dir
 
     @classmethod
-    def download_model(cls, model: Dict[str, Any], cache_dir: Path) -> Path:
+    def download_model(cls, model: Dict[str, Any], cache_dir: Path, **kwargs) -> Path:
         """
         Downloads a model from HuggingFace Hub or Google Cloud Storage.
 
@@ -224,7 +226,8 @@ class ModelManagement:
             try:
                 return Path(
                     cls.download_files_from_huggingface(
-                        hf_source, cache_dir=str(cache_dir), extra_patterns=extra_patterns
+                        hf_source, cache_dir=str(cache_dir), extra_patterns=extra_patterns,
+                        local_files_only = kwargs.get('local_files_only', False)
                     )
                 )
             except (EnvironmentError, RepositoryNotFoundError, ValueError) as e:

--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -91,7 +91,7 @@ class ModelManagement:
         hf_source_repo: str,
         cache_dir: Optional[str] = None,
         extra_patterns: Optional[List[str]] = None,
-        **kwargs
+        **kwargs,
     ) -> str:
         """
         Downloads a model from HuggingFace Hub.
@@ -116,7 +116,7 @@ class ModelManagement:
             repo_id=hf_source_repo,
             allow_patterns=allow_patterns,
             cache_dir=cache_dir,
-            local_files_only=kwargs.get('local_files_only', False)
+            local_files_only=kwargs.get("local_files_only", False),
         )
 
     @classmethod
@@ -226,8 +226,10 @@ class ModelManagement:
             try:
                 return Path(
                     cls.download_files_from_huggingface(
-                        hf_source, cache_dir=str(cache_dir), extra_patterns=extra_patterns,
-                        local_files_only = kwargs.get('local_files_only', False)
+                        hf_source,
+                        cache_dir=str(cache_dir),
+                        extra_patterns=extra_patterns,
+                        local_files_only=kwargs.get("local_files_only", False),
                     )
                 )
             except (EnvironmentError, RepositoryNotFoundError, ValueError) as e:

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -32,6 +32,7 @@ class SparseTextEmbeddingBase(ModelManagement):
         self.model_name = model_name
         self.cache_dir = cache_dir
         self.threads = threads
+        self._local_files_only = kwargs.pop("local_files_only", False)
 
     def embed(
         self,

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -82,7 +82,9 @@ class SpladePP(SparseTextEmbeddingBase, OnnxModel[SparseEmbedding]):
         model_description = self._get_model_description(model_name)
         cache_dir = define_cache_dir(cache_dir)
 
-        model_dir = self.download_model(model_description, cache_dir)
+        model_dir = self.download_model(
+            model_description, cache_dir, local_files_only=self._local_files_only
+        )
 
         self.load_onnx_model(
             model_dir=model_dir,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -229,7 +229,8 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxModel[np.ndarray]):
 
         model_description = self._get_model_description(model_name)
         cache_dir = define_cache_dir(cache_dir)
-        model_dir = self.download_model(model_description, cache_dir)
+        local_files_only = kwargs.get('local_files_only', False)
+        model_dir = self.download_model(model_description, cache_dir, local_files_only=local_files_only)
 
         self.load_onnx_model(
             model_dir=model_dir,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -229,8 +229,9 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxModel[np.ndarray]):
 
         model_description = self._get_model_description(model_name)
         cache_dir = define_cache_dir(cache_dir)
-        local_files_only = kwargs.get('local_files_only', False)
-        model_dir = self.download_model(model_description, cache_dir, local_files_only=local_files_only)
+        model_dir = self.download_model(
+            model_description, cache_dir, local_files_only=self._local_files_only
+        )
 
         self.load_onnx_model(
             model_dir=model_dir,

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -16,7 +16,7 @@ class TextEmbeddingBase(ModelManagement):
         self.model_name = model_name
         self.cache_dir = cache_dir
         self.threads = threads
-        self.local_files_only = kwargs.get('local_files_only', False)
+        self._local_files_only = kwargs.pop("local_files_only", False)
 
     def embed(
         self,

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -16,6 +16,7 @@ class TextEmbeddingBase(ModelManagement):
         self.model_name = model_name
         self.cache_dir = cache_dir
         self.threads = threads
+        self.local_files_only = kwargs.get('local_files_only', False)
 
     def embed(
         self,


### PR DESCRIPTION
Linked issue: https://github.com/qdrant/fastembed/issues/218

This allows the user to select local_files_only and bypass network calls, allowing it to be used behind firewalls.