### PR TITLE
Colbert

### DIFF
--- a/fastembed/__init__.py
+++ b/fastembed/__init__.py
@@ -3,7 +3,7 @@ import importlib.metadata
 from fastembed.image import ImageEmbedding
 from fastembed.text import TextEmbedding
 from fastembed.sparse import SparseTextEmbedding, SparseEmbedding
-
+from fastembed.late_interaction import LateInteractionTextEmbedding
 
 try:
     version = importlib.metadata.version("fastembed")
@@ -11,5 +11,10 @@ except importlib.metadata.PackageNotFoundError as _:
     version = importlib.metadata.version("fastembed-gpu")
 
 __version__ = version
-__all__ = ["TextEmbedding", "SparseTextEmbedding", "SparseEmbedding", "ImageEmbedding"]
-
+__all__ = [
+    "TextEmbedding",
+    "SparseTextEmbedding",
+    "SparseEmbedding",
+    "ImageEmbedding",
+    "LateInteractionTextEmbedding",
+]

--- a/fastembed/common/onnx_model.py
+++ b/fastembed/common/onnx_model.py
@@ -33,7 +33,9 @@ class OnnxModel(Generic[T]):
         self.model = None
         self.tokenizer = None
 
-    def _preprocess_onnx_input(self, onnx_input: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    def _preprocess_onnx_input(
+        self, onnx_input: Dict[str, np.ndarray], **kwargs
+    ) -> Dict[str, np.ndarray]:
         """
         Preprocess the onnx input.
         """

--- a/fastembed/image/onnx_embedding.py
+++ b/fastembed/image/onnx_embedding.py
@@ -112,7 +112,9 @@ class OnnxImageEmbedding(ImageEmbeddingBase, OnnxImageModel[np.ndarray]):
     def _get_worker_class(cls) -> Type["ImageEmbeddingWorker"]:
         return OnnxImageEmbeddingWorker
 
-    def _preprocess_onnx_input(self, onnx_input: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    def _preprocess_onnx_input(
+        self, onnx_input: Dict[str, np.ndarray], **kwargs
+    ) -> Dict[str, np.ndarray]:
         """
         Preprocess the onnx input.
         """

--- a/fastembed/image/onnx_image_model.py
+++ b/fastembed/image/onnx_image_model.py
@@ -28,7 +28,9 @@ class OnnxImageModel(OnnxModel[T]):
         super().__init__()
         self.processor = None
 
-    def _preprocess_onnx_input(self, onnx_input: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    def _preprocess_onnx_input(
+        self, onnx_input: Dict[str, np.ndarray], **kwargs
+    ) -> Dict[str, np.ndarray]:
         """
         Preprocess the onnx input.
         """
@@ -49,16 +51,14 @@ class OnnxImageModel(OnnxModel[T]):
     def _build_onnx_input(self, encoded: np.ndarray) -> Dict[str, np.ndarray]:
         return {node.name: encoded for node in self.model.get_inputs()}
 
-    def onnx_embed(self, images: List[PathInput]) -> OnnxOutputContext:
+    def onnx_embed(self, images: List[PathInput], **kwargs) -> OnnxOutputContext:
         with contextlib.ExitStack():
             image_files = [Image.open(image) for image in images]
             encoded = self.processor(image_files)
         onnx_input = self._build_onnx_input(encoded)
         onnx_input = self._preprocess_onnx_input(onnx_input)
         model_output = self.model.run(None, onnx_input)
-
         embeddings = model_output[0].reshape(len(images), -1)
-
         return OnnxOutputContext(
             model_output=embeddings
         )

--- a/fastembed/late_interaction/__init__.py
+++ b/fastembed/late_interaction/__init__.py
@@ -1,0 +1,4 @@
+from fastembed.late_interaction.late_interaction_text_embedding import LateInteractionTextEmbedding
+
+
+__all__ = ["LateInteractionTextEmbedding"]

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -29,7 +29,7 @@ supported_colbert_models = [
 class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
     QUERY_MARKER_TOKEN_ID = 1
     DOCUMENT_MARKER_TOKEN_ID = 2
-    MIN_QUERY_LENGTH = 32  # colbert recommends to pad queries with [MASK] for query augmentation
+    MIN_QUERY_LENGTH = 32
     MASK_TOKEN = "[MASK]"
 
     @classmethod
@@ -53,8 +53,10 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
         )
 
     def _tokenize_query(self, query: str) -> List[Encoding]:
+        # ". " is added to a query to be replaced with a special query token
         query = [f". {query}"]
         encoded = self.tokenizer.encode_batch(query)
+        # colbert authors recommend to pad queries with [MASK] tokens for query augmentation to improve performance
         if len(encoded[0].ids) < self.MIN_QUERY_LENGTH:
             self.tokenizer.enable_padding(
                 pad_token=self.MASK_TOKEN, pad_id=self.mask_token_id, length=self.MIN_QUERY_LENGTH
@@ -64,6 +66,7 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
         return encoded
 
     def _tokenize_documents(self, documents: List[str]) -> List[Encoding]:
+        # ". " is added to a document to be replaced with a special document token
         documents = [". " + doc for doc in documents]
         encoded = self.tokenizer.encode_batch(documents)
         return encoded

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -58,11 +58,17 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
         encoded = self.tokenizer.encode_batch(query)
         # colbert authors recommend to pad queries with [MASK] tokens for query augmentation to improve performance
         if len(encoded[0].ids) < self.MIN_QUERY_LENGTH:
+            prev_padding = None
+            if self.tokenizer.padding:
+                prev_padding = self.tokenizer.padding
             self.tokenizer.enable_padding(
                 pad_token=self.MASK_TOKEN, pad_id=self.mask_token_id, length=self.MIN_QUERY_LENGTH
             )
             encoded = self.tokenizer.encode_batch(query)
-            self.tokenizer.no_padding()
+            if prev_padding is None:
+                self.tokenizer.no_padding()
+            else:
+                self.tokenizer.enable_padding(**prev_padding)
         return encoded
 
     def _tokenize_documents(self, documents: List[str]) -> List[Encoding]:

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -1,0 +1,165 @@
+from typing import Any, Dict, Iterable, List, Optional, Union, Type, Sequence
+
+import numpy as np
+from tokenizers import Encoding
+
+from fastembed.common import OnnxProvider
+from fastembed.common.onnx_model import OnnxOutputContext, T
+from fastembed.common.utils import define_cache_dir
+from fastembed.late_interaction.late_interaction_embedding_base import (
+    LateInteractionTextEmbeddingBase,
+)
+from fastembed.text.onnx_text_model import OnnxTextModel, TextEmbeddingWorker
+
+
+supported_colbert_models = [
+    {
+        "model": "colbert-ir/colbertv2.0",
+        "dim": 128,
+        "description": "Late interaction model",
+        "size_in_GB": 0.44,
+        "sources": {
+            "hf": "colbert-ir/colbertv2.0",
+        },
+        "model_file": "model.onnx",
+    }
+]
+
+
+class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
+    QUERY_MARKER_TOKEN_ID = 1
+    DOCUMENT_MARKER_TOKEN_ID = 2
+    MIN_QUERY_LENGTH = 32  # colbert recommends to pad queries with [MASK] for query augmentation
+    MASK_TOKEN = "[MASK]"
+
+    @classmethod
+    def _post_process_onnx_output(cls, output: OnnxOutputContext) -> Iterable[T]:
+        return output.model_output.astype(np.float32)
+
+    def _preprocess_onnx_input(
+        self, onnx_input: Dict[str, np.ndarray], is_doc: bool = True
+    ) -> Dict[str, np.ndarray]:
+        if is_doc:
+            onnx_input["input_ids"][:, 1] = self.DOCUMENT_MARKER_TOKEN_ID
+        else:
+            onnx_input["input_ids"][:, 1] = self.QUERY_MARKER_TOKEN_ID
+        return onnx_input
+
+    def tokenize(self, documents: List[str], is_doc: bool = True) -> List[Encoding]:
+        return (
+            self._tokenize_documents(documents=documents)
+            if is_doc
+            else self._tokenize_query(query=next(iter(documents)))
+        )
+
+    def _tokenize_query(self, query: str) -> List[Encoding]:
+        query = [f". {query}"]
+        encoded = self.tokenizer.encode_batch(query)
+        if len(encoded[0].ids) < self.MIN_QUERY_LENGTH:
+            self.tokenizer.enable_padding(
+                pad_token=self.MASK_TOKEN, pad_id=self.mask_token_id, length=self.MIN_QUERY_LENGTH
+            )
+            encoded = self.tokenizer.encode_batch(query)
+            self.tokenizer.no_padding()
+        return encoded
+
+    def _tokenize_documents(self, documents: List[str]) -> List[Encoding]:
+        documents = [". " + doc for doc in documents]
+        encoded = self.tokenizer.encode_batch(documents)
+        return encoded
+
+    @classmethod
+    def list_supported_models(cls) -> List[Dict[str, Any]]:
+        """Lists the supported models.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing the model information.
+        """
+        return supported_colbert_models
+
+    def __init__(
+        self,
+        model_name: str,
+        cache_dir: Optional[str] = None,
+        threads: Optional[int] = None,
+        providers: Optional[Sequence[OnnxProvider]] = None,
+        **kwargs,
+    ):
+        """
+        Args:
+            model_name (str): The name of the model to use.
+            cache_dir (str, optional): The path to the cache directory.
+                                       Can be set using the `FASTEMBED_CACHE_PATH` env variable.
+                                       Defaults to `fastembed_cache` in the system's temp directory.
+            threads (int, optional): The number of threads single onnxruntime session can use. Defaults to None.
+
+        Raises:
+            ValueError: If the model_name is not in the format <org>/<model> e.g. BAAI/bge-base-en.
+        """
+
+        super().__init__(model_name, cache_dir, threads, **kwargs)
+
+        model_description = self._get_model_description(model_name)
+        cache_dir = define_cache_dir(cache_dir)
+
+        model_dir = self.download_model(
+            model_description, cache_dir, local_files_only=self._local_files_only
+        )
+
+        self.load_onnx_model(
+            model_dir=model_dir,
+            model_file=model_description["model_file"],
+            threads=threads,
+            providers=providers,
+        )
+        self.mask_token_id = self.special_token_to_id["[MASK]"]
+
+    def embed(
+        self,
+        documents: Union[str, Iterable[str]],
+        batch_size: int = 256,
+        parallel: Optional[int] = None,
+        **kwargs,
+    ) -> Iterable[np.ndarray]:
+        """
+        Encode a list of documents into list of embeddings.
+        We use mean pooling with attention so that the model can handle variable-length inputs.
+
+        Args:
+            documents: Iterator of documents or single document to embed
+            batch_size: Batch size for encoding -- higher values will use more memory, but be faster
+            parallel:
+                If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
+                If 0, use all available cores.
+                If None, don't use data-parallel processing, use default onnxruntime threading instead.
+
+        Returns:
+            List of embeddings, one per document
+        """
+        yield from self._embed_documents(
+            model_name=self.model_name,
+            cache_dir=str(self.cache_dir),
+            documents=documents,
+            batch_size=batch_size,
+            parallel=parallel,
+        )
+
+    def query_embed(self, query: Union[str, List[str]], **kwargs) -> np.ndarray:
+        if isinstance(query, str):
+            query = [query]
+
+        for text in query:
+            yield from self._post_process_onnx_output(self.onnx_embed([text], is_doc=False))
+
+    @classmethod
+    def _get_worker_class(cls) -> Type[TextEmbeddingWorker]:
+        return ColbertEmbeddingWorker
+
+
+class ColbertEmbeddingWorker(TextEmbeddingWorker):
+    def init_embedding(
+        self,
+        model_name: str,
+        cache_dir: str,
+    ) -> Colbert:
+        return Colbert(model_name=model_name, cache_dir=cache_dir, threads=1)

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -1,0 +1,60 @@
+from typing import Iterable, Optional, Union
+
+import numpy as np
+
+from fastembed.common.model_management import ModelManagement
+
+
+class LateInteractionTextEmbeddingBase(ModelManagement):
+    def __init__(
+        self,
+        model_name: str,
+        cache_dir: Optional[str] = None,
+        threads: Optional[int] = None,
+        **kwargs,
+    ):
+        self.model_name = model_name
+        self.cache_dir = cache_dir
+        self.threads = threads
+        self._local_files_only = kwargs.pop("local_files_only", False)
+
+    def embed(
+        self,
+        documents: Union[str, Iterable[str]],
+        batch_size: int = 256,
+        parallel: Optional[int] = None,
+        **kwargs,
+    ) -> Iterable[np.ndarray]:
+        raise NotImplementedError()
+
+    def passage_embed(self, texts: Iterable[str], **kwargs) -> Iterable[np.ndarray]:
+        """
+        Embeds a list of text passages into a list of embeddings.
+
+        Args:
+            texts (Iterable[str]): The list of texts to embed.
+            **kwargs: Additional keyword argument to pass to the embed method.
+
+        Yields:
+            Iterable[np.ndarray]: The embeddings.
+        """
+
+        # This is model-specific, so that different models can have specialized implementations
+        yield from self.embed(texts, **kwargs)
+
+    def query_embed(self, query: Union[str, Iterable[str]], **kwargs) -> Iterable[np.ndarray]:
+        """
+        Embeds queries
+
+        Args:
+            query (Union[str, Iterable[str]]): The query to embed, or an iterable e.g. list of queries.
+
+        Returns:
+            Iterable[np.ndarray]: The embeddings.
+        """
+
+        # This is model-specific, so that different models can have specialized implementations
+        if isinstance(query, str):
+            yield from self.embed([query], **kwargs)
+        if isinstance(query, Iterable):
+            yield from self.embed(query, **kwargs)

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -1,0 +1,104 @@
+from typing import List, Type, Dict, Any, Union, Iterable, Optional, Sequence
+
+import numpy as np
+
+from fastembed.common import OnnxProvider
+from fastembed.late_interaction.late_interaction_embedding_base import (
+    LateInteractionTextEmbeddingBase,
+)
+from fastembed.late_interaction.colbert import Colbert
+
+
+class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
+    EMBEDDINGS_REGISTRY: List[Type[LateInteractionTextEmbeddingBase]] = [
+        Colbert,
+    ]
+
+    @classmethod
+    def list_supported_models(cls) -> List[Dict[str, Any]]:
+        """
+        Lists the supported models.
+
+        Returns:
+            List[Dict[str, Any]]: A list of dictionaries containing the model information.
+
+            Example:
+                ```
+                [
+                    {
+                        "model": "prithvida/SPLADE_PP_en_v1",
+                        "vocab_size": 30522,
+                        "description": "Independent Implementation of SPLADE++ Model for English",
+                        "size_in_GB": 0.532,
+                        "sources": {
+                            "hf": "qdrant/SPLADE_PP_en_v1",
+                        },
+                    }
+                ]
+                ```
+        """
+        result = []
+        for embedding in cls.EMBEDDINGS_REGISTRY:
+            result.extend(embedding.list_supported_models())
+        return result
+
+    def __init__(
+        self,
+        model_name: str,
+        cache_dir: Optional[str] = None,
+        threads: Optional[int] = None,
+        providers: Optional[Sequence[OnnxProvider]] = None,
+        **kwargs,
+    ):
+        super().__init__(model_name, cache_dir, threads, **kwargs)
+
+        for EMBEDDING_MODEL_TYPE in self.EMBEDDINGS_REGISTRY:
+            supported_models = EMBEDDING_MODEL_TYPE.list_supported_models()
+            if any(model_name.lower() == model["model"].lower() for model in supported_models):
+                self.model = EMBEDDING_MODEL_TYPE(
+                    model_name, cache_dir, threads, providers=providers, **kwargs
+                )
+                return
+
+        raise ValueError(
+            f"Model {model_name} is not supported in SparseTextEmbedding."
+            "Please check the supported models using `SparseTextEmbedding.list_supported_models()`"
+        )
+
+    def embed(
+        self,
+        documents: Union[str, Iterable[str]],
+        batch_size: int = 256,
+        parallel: Optional[int] = None,
+        **kwargs,
+    ) -> Iterable[np.ndarray]:
+        """
+        Encode a list of documents into list of embeddings.
+        We use mean pooling with attention so that the model can handle variable-length inputs.
+
+        Args:
+            documents: Iterator of documents or single document to embed
+            batch_size: Batch size for encoding -- higher values will use more memory, but be faster
+            parallel:
+                If > 1, data-parallel encoding will be used, recommended for offline encoding of large datasets.
+                If 0, use all available cores.
+                If None, don't use data-parallel processing, use default onnxruntime threading instead.
+
+        Returns:
+            List of embeddings, one per document
+        """
+        yield from self.model.embed(documents, batch_size, parallel, **kwargs)
+
+    def query_embed(self, query: Union[str, Iterable[str]], **kwargs) -> Iterable[np.ndarray]:
+        """
+        Embeds queries
+
+        Args:
+            query (Union[str, Iterable[str]]): The query to embed, or an iterable e.g. list of queries.
+
+        Returns:
+            Iterable[np.ndarray]: The embeddings.
+        """
+
+        # This is model-specific, so that different models can have specialized implementations
+        yield from self.model.query_embed(query, **kwargs)

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, Tuple, Union, Iterable, Type, List, Any, Sequence
+from typing import Dict, Optional, Union, Iterable, Type, List, Any, Sequence
 
 import numpy as np
 
@@ -277,15 +277,15 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[np.ndarray]):
     def _get_worker_class(cls) -> Type["TextEmbeddingWorker"]:
         return OnnxTextEmbeddingWorker
 
-    def _preprocess_onnx_input(self, onnx_input: Dict[str, np.ndarray]) -> Dict[str, np.ndarray]:
+    def _preprocess_onnx_input(
+        self, onnx_input: Dict[str, np.ndarray], **kwargs
+    ) -> Dict[str, np.ndarray]:
         """
         Preprocess the onnx input.
         """
         return onnx_input
 
-    def _post_process_onnx_output(
-        self, output: OnnxOutputContext
-    ) -> Iterable[np.ndarray]:
+    def _post_process_onnx_output(self, output: OnnxOutputContext) -> Iterable[np.ndarray]:
         embeddings = output.model_output
         return normalize(embeddings[:, 0]).astype(np.float32)
 

--- a/fastembed/text/onnx_text_model.py
+++ b/fastembed/text/onnx_text_model.py
@@ -75,8 +75,8 @@ class OnnxTextModel(OnnxModel[T]):
         model_output = self.model.run(self.ONNX_OUTPUT_NAMES, onnx_input)
         return OnnxOutputContext(
             model_output=model_output[0],
-            attention_mask=attention_mask,
-            input_ids=input_ids,
+            attention_mask=onnx_input.get("attention_mask", attention_mask),
+            input_ids=onnx_input.get("input_ids", input_ids),
         )
 
     def _embed_documents(

--- a/fastembed/text/onnx_text_model.py
+++ b/fastembed/text/onnx_text_model.py
@@ -1,4 +1,5 @@
 import os
+from multiprocessing import get_all_start_methods
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Tuple, Type, Union, Sequence
 
@@ -103,8 +104,7 @@ class OnnxTextModel(OnnxModel[T]):
             for batch in iter_batch(documents, batch_size):
                 yield from self._post_process_onnx_output(self.onnx_embed(batch))
         else:
-            # start_method = "forkserver" if "forkserver" in get_all_start_methods() else "spawn"
-            start_method = "fork"
+            start_method = "forkserver" if "forkserver" in get_all_start_methods() else "spawn"
             params = {
                 "model_name": model_name,
                 "cache_dir": cache_dir,

--- a/tests/test_late_interaction_embeddings.py
+++ b/tests/test_late_interaction_embeddings.py
@@ -1,0 +1,113 @@
+import numpy as np
+
+from fastembed.late_interaction.late_interaction_text_embedding import LateInteractionTextEmbedding
+
+
+# vectors are abridged and rounded for brevity
+CANONICAL_COLUMN_VALUES = {
+    "colbert-ir/colbertv2.0": np.array(
+        [
+            [0.0759, 0.0841, -0.0299, 0.0374, 0.0254],
+            [0.0005, -0.0163, -0.0127, 0.2165, 0.1517],
+            [-0.0257, -0.0575, 0.0135, 0.2202, 0.1896],
+            [0.0846, 0.0122, 0.0032, -0.0109, -0.1041],
+            [0.0477, 0.1078, -0.0314, 0.016, 0.0156],
+        ]
+    )
+}
+
+CANONICAL_QUERY_VALUES = {
+    "colbert-ir/colbertv2.0": np.array(
+        [
+            [0.0824, 0.0872, -0.0324, 0.0418, 0.024],
+            [-0.0007, -0.0154, -0.0113, 0.2277, 0.1528],
+            [-0.0251, -0.0565, 0.0136, 0.2236, 0.1838],
+            [0.0848, 0.0056, 0.0041, -0.0036, -0.1032],
+            [0.0574, 0.1072, -0.0332, 0.0233, 0.0209],
+            [0.1041, 0.0364, -0.0058, -0.027, -0.0704],
+            [0.106, 0.0371, -0.0055, -0.0339, -0.0719],
+            [0.1063, 0.0363, 0.0014, -0.0334, -0.0698],
+            [0.112, 0.036, 0.0026, -0.0355, -0.0675],
+            [0.1184, 0.0441, 0.0166, -0.0169, -0.0244],
+            [0.1033, 0.035, 0.0183, 0.0475, 0.0612],
+            [-0.0028, -0.014, -0.016, 0.2175, 0.1537],
+            [0.0547, 0.0219, -0.007, 0.1748, 0.1154],
+            [-0.001, -0.0184, -0.0112, 0.2197, 0.1523],
+            [-0.0012, -0.0149, -0.0119, 0.2147, 0.152],
+            [-0.0186, -0.0239, -0.014, 0.2196, 0.156],
+            [-0.017, -0.0232, -0.0108, 0.2212, 0.157],
+            [-0.0109, -0.0024, -0.003, 0.1972, 0.1391],
+            [0.0898, 0.0219, -0.0255, 0.0734, -0.0096],
+            [0.1143, 0.015, -0.022, 0.0417, -0.0421],
+            [0.1056, 0.0091, -0.0137, 0.0129, -0.0619],
+            [0.0234, 0.004, -0.0285, 0.1565, 0.0883],
+            [-0.0037, -0.0079, -0.0204, 0.1982, 0.1502],
+            [0.0988, 0.0377, 0.0226, 0.0309, 0.0508],
+            [-0.0103, -0.0128, -0.0035, 0.2114, 0.155],
+            [-0.0103, -0.0184, -0.011, 0.2252, 0.157],
+            [-0.0033, -0.0292, -0.0097, 0.2237, 0.1607],
+            [-0.0198, -0.0257, -0.0193, 0.2265, 0.165],
+            [-0.0227, -0.0028, -0.0084, 0.1995, 0.1306],
+            [0.0916, 0.0185, -0.0186, 0.0173, -0.0577],
+            [0.1022, 0.0228, -0.0174, -0.0102, -0.065],
+            [0.1043, 0.0231, -0.0144, -0.0246, -0.067],
+        ]
+    )
+}
+
+docs = ["Hello World"]
+
+
+def test_batch_embedding():
+    docs_to_embed = docs * 10
+
+    for model_name, expected_result in CANONICAL_COLUMN_VALUES.items():
+        print("evaluating", model_name)
+        model = LateInteractionTextEmbedding(model_name=model_name)
+        result = list(model.embed(docs_to_embed, batch_size=6))
+
+        for value in result:
+            token_num, abridged_dim = expected_result.shape
+            assert np.allclose(value[:, :abridged_dim], expected_result, atol=10e-4)
+
+
+def test_single_embedding():
+    docs_to_embed = docs
+
+    for model_name, expected_result in CANONICAL_COLUMN_VALUES.items():
+        print("evaluating", model_name)
+        model = LateInteractionTextEmbedding(model_name=model_name, cache_dir="colbert-cache")
+        result = next(iter(model.embed(docs_to_embed, batch_size=6)))
+        token_num, abridged_dim = expected_result.shape
+        assert np.allclose(result[:, :abridged_dim], expected_result, atol=10e-4)
+
+
+def test_single_embedding_query():
+    queries_to_embed = docs
+
+    for model_name, expected_result in CANONICAL_QUERY_VALUES.items():
+        print("evaluating", model_name)
+        model = LateInteractionTextEmbedding(model_name=model_name, cache_dir="colbert-cache")
+        result = next(iter(model.query_embed(queries_to_embed)))
+        token_num, abridged_dim = expected_result.shape
+        assert np.allclose(result[:, :abridged_dim], expected_result, atol=10e-4)
+
+
+def test_parallel_processing():
+    model = LateInteractionTextEmbedding(
+        model_name="colbert-ir/colbertv2.0", cache_dir="colbert-cache"
+    )
+    token_dim = 128
+    docs = ["hello world", "flag embedding"] * 100
+    embeddings = list(model.embed(docs, batch_size=10, parallel=2))
+    embeddings = np.stack(embeddings, axis=0)
+
+    embeddings_2 = list(model.embed(docs, batch_size=10, parallel=None))
+    embeddings_2 = np.stack(embeddings_2, axis=0)
+
+    embeddings_3 = list(model.embed(docs, batch_size=10, parallel=0))
+    embeddings_3 = np.stack(embeddings_3, axis=0)
+
+    assert embeddings.shape[0] == len(docs) and embeddings.shape[-1] == token_dim
+    assert np.allclose(embeddings, embeddings_2, atol=1e-3)
+    assert np.allclose(embeddings, embeddings_3, atol=1e-3)


### PR DESCRIPTION
This PR adds classes for late interaction embeddings.
The only supported model at the moment is [colbertv2.0](https://huggingface.co/colbert-ir/colbertv2.0)

A few complexities in this PR are bound to the way colbert processes documents and queries.
It adds a special token `[Q]` or `[D]` as a second token in a sequence of tokens.
They should be added as token ids to be processed correctly.

Another complexity is that colbert authors recommend to pad queries with [MASK] tokens for query augmentation which leads to a better retrieval quality. Padding extends the query to 32 tokens.

Official colbert library allocates 32 tokens for query + (512 - 32 - 1) for context. 
[link to query tokenizer](https://github.com/stanford-futuredata/ColBERT/blob/main/colbert/modeling/tokenization/query_tokenization.py#L53)

We don't do such a separation, instead we just limit query to 512 tokens.

Colbert also requires removing punctuation tokens, which is being done after inference stage via modifying attention mask and the consequent multiplication of the model's output and updated attention mask.