### PR TITLE
Add support for jinaai/jina-embeddings-v2-base-de

### DIFF
--- a/fastembed/text/jina_onnx_embedding.py
+++ b/fastembed/text/jina_onnx_embedding.py
@@ -24,6 +24,14 @@ supported_jina_models = [
         "sources": {"hf": "xenova/jina-embeddings-v2-small-en"},
         "model_file": "onnx/model.onnx",
     },
+    {
+        "model": "jinaai/jina-embeddings-v2-base-de",
+        "dim": 768,
+        "description": "German embedding model supporting 8192 sequence length",
+        "size_in_GB": 0.16,
+        "sources": {"hf": "jinaai/jina-embeddings-v2-base-de"},
+        "model_file": "onnx/model_fp16.onnx",
+    },
 ]
 
 

--- a/fastembed/text/jina_onnx_embedding.py
+++ b/fastembed/text/jina_onnx_embedding.py
@@ -28,7 +28,7 @@ supported_jina_models = [
         "model": "jinaai/jina-embeddings-v2-base-de",
         "dim": 768,
         "description": "German embedding model supporting 8192 sequence length",
-        "size_in_GB": 0.16,
+        "size_in_GB": 0.32,
         "sources": {"hf": "jinaai/jina-embeddings-v2-base-de"},
         "model_file": "onnx/model_fp16.onnx",
     },

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -36,6 +36,7 @@ CANONICAL_VECTOR_VALUES = {
     ),
     "jinaai/jina-embeddings-v2-small-en": np.array([-0.0455, -0.0428, -0.0122, 0.0613, 0.0015]),
     "jinaai/jina-embeddings-v2-base-en": np.array([-0.0332, -0.0509, 0.0287, -0.0043, -0.0077]),
+    "jinaai/jina-embeddings-v2-base-de": np.array([-0.0085, 0.0417, 0.0342, 0.0309, -0.0149]),
     "nomic-ai/nomic-embed-text-v1": np.array([0.0061, 0.0103, -0.0296, -0.0242, -0.0170]),
     "nomic-ai/nomic-embed-text-v1.5": np.array(
         [-1.6531514e-02, 8.5380634e-05, -1.8171231e-01, -3.9333291e-03, 1.2763254e-02]


### PR DESCRIPTION
## Issue
This PR resolves #266. 

A new version of jina embeddings was added: 

```
    {
        "model": "jinaai/jina-embeddings-v2-base-de",
        "dim": 768,
        "description": "German embedding model supporting 8192 sequence length",
        "size_in_GB": 0.16,
        "sources": {"hf": "jinaai/jina-embeddings-v2-base-de"},
        "model_file": "onnx/model_fp16.onnx",
    },
```
The quantized, onnx exported model is directly hosted by `jinaai`.

## Changes

The following files were changed to add this model: 
- `fastembed/text/jina_onnx_embedding.py`: Model definition was added
- `tests/test_text_onnx_embeddings.py`: Test was added,  where the expected data was created with the supplied Colab-Notebook

  ```
  from sentence_transformers import SentenceTransformer
  model = SentenceTransformer('jinaai/jina-embeddings-v2-base-de', trust_remote_code=True)
  input_texts = [
      "hello world", "flag embedding"
  ]
  embeddings = model.encode(input_texts, normalize_embeddings=True)
  print(embeddings[0][:5])
  ```
  ```
  [-0.00857827  0.04176599  0.03420503  0.0309742  -0.01496792]
  ```

## Tests
All tests passed after the changes.

