### PR TITLE
chore: mmh3.hash(token, signed=False) instead of abs()

### DIFF
--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -237,7 +237,7 @@ class Bm25(SparseTextEmbeddingBase):
 
     @classmethod
     def compute_token_id(cls, token: str) -> int:
-        return abs(mmh3.hash(token))
+        return mmh3.hash(token, signed=False)
 
     def query_embed(self, query: Union[str, Iterable[str]], **kwargs) -> Iterable[SparseEmbedding]:
         """To emulate BM25 behaviour, we don't need to use weights in the query, and

--- a/fastembed/sparse/bm42.py
+++ b/fastembed/sparse/bm42.py
@@ -169,7 +169,7 @@ class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
         new_vector = {}
 
         for token, value in vector.items():
-            token_id = abs(mmh3.hash(token))
+            token_id = mmh3.hash(token, signed=False)
             # Examples:
             # Num 0: Log(1/1 + 1) = 0.6931471805599453
             # Num 1: Log(1/2 + 1) = 0.4054651081081644
@@ -260,7 +260,7 @@ class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
     def _query_rehash(cls, tokens: Iterable[str]) -> Dict[int, float]:
         result = {}
         for token in tokens:
-            token_id = abs(mmh3.hash(token))
+            token_id = mmh3.hash(token, signed=False)
             result[token_id] = 1.0
         return result
 


### PR DESCRIPTION
## Description

I found this is the right way to get unsigned hashes. It generates bigger/stronger values.

Running

```py
import mmh3

abs(mmh3.hash("today"))
```

returns `22861070`. Whereas

```py
import mmh3

mmh3.hash("today", signed=False)
```

returns `4272106226`.

The latter is also consitent with the hashes generated in other langs like https://docs.rs/murmur3/latest/murmur3/.

