### PR TITLE
Remove numpy<2 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ tokenizers = ">=0.15,<1.0"
 huggingface-hub = ">=0.20,<1.0"
 loguru = "^0.7.2"
 numpy = [
-    { version = ">=1.21, <2", python = "<3.12" },
-    { version = ">=1.26, <2", python = ">=3.12" }
+    { version = ">=1.21", python = "<3.12" },
+    { version = ">=1.26", python = ">=3.12" }
 ]
 pillow = "^10.3.0"
 mmh3 = "^4.1.0"


### PR DESCRIPTION
This causes an incompatibility with spaCy>=3.8.0 because no matching versions of numpy can be found when using both libraries at once.

It looks like the tests pass again without the numpy<2 requirement so there is no reason to keep this requirement anymore.