### PR TITLE
Fix:  cache_dir.mkdir is causing issue when cache_dir is readonly

### DIFF
--- a/fastembed/common/utils.py
+++ b/fastembed/common/utils.py
@@ -40,7 +40,9 @@ def define_cache_dir(cache_dir: Optional[str] = None) -> Path:
         cache_path = Path(os.getenv("FASTEMBED_CACHE_PATH", default_cache_dir))
     else:
         cache_path = Path(cache_dir)
-    cache_path.mkdir(parents=True, exist_ok=True)
+
+    if not cache_path.exists():
+        cache_path.mkdir(parents=True, exist_ok=True)
 
     return cache_path
 


### PR DESCRIPTION
When deploying application in production, there would be cases where models are pre-downloaded and mounted as read only folder for image to use.

This pull request checks if cache_dir already exists before trying to 'mkdir' to avoid permission issue.