### PR TITLE
chore: Lock onnxruntime version to be < 1.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["vector", "embedding", "neural", "search", "qdrant", "sentence-trans
 [tool.poetry.dependencies]
 python = ">=3.8.0,<3.13"
 onnx = "^1.15.0"
-onnxruntime = "^1.17.0"
+onnxruntime = ">=1.17.0,<1.20.0"
 tqdm = "^4.66"
 requests = "^2.31"
 tokenizers = ">=0.15,<1.0"


### PR DESCRIPTION
The latest version of onnxruntime (1.20.0) breaks the compatibility of some layers on previously created models. So locking the version to be < 1.20.0 tell they fix the issue.