### PR TITLE
Update GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,6 +1,6 @@
-name: Bug/New Model Request
-description: File a bug report/Request a new Model
-title: "[Bug/Model Request]: "
+name: Bug
+description: File a bug report
+title: "[Bug]: "
 body:
   - type: markdown
     attributes:
@@ -10,11 +10,22 @@ body:
     id: what-happened
     attributes:
       label: What happened?
-      description: Also tell us, what did you expect to happen?
-      placeholder: Tell us what you see!
-      value: "A bug happened!"
+      description: Describe the error you encountered.
+      placeholder: <Description>
     validations:
       required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What is the expected behaviour?
+      description: Describe the way you expected the code to behave.
+      placeholder: <Description>
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: A minimal reproducible example
+      description: It would really help us to fix the problem if you could provide a code snippet that reproduces the issue.
+      placeholder: <Code snippet>
   - type: textarea
     id: python-version
     attributes:
@@ -23,21 +34,12 @@ body:
       placeholder: Python3.10
     validations:
       required: true
-  - type: dropdown
+  - type: textarea
     id: version
     attributes:
-      label: Version
+      label: FastEmbed version
       description: What version of FastEmbed are you running? python -c "import fastembed; print(fastembed.__version__)". If you're not on the latest, please upgrade and see if the problem persists.
-      options:
-        - 0.2.7 (Latest)
-        - 0.2.6
-        - 0.2.5
-        - 0.2.4 
-        - 0.2.3 
-        - 0.2.2
-        - 0.2.1
-        - 0.1.x 
-      default: 0
+      placeholder: v0.4.2
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: GitHub Community Support
     url: https://github.com/qdrant/fastembed/discussions

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,22 @@
+name: Feature
+description: New functionality request
+title: "[Feature]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this report!
+  - type: textarea
+    id: feature-description
+    attributes:
+      label: What feature would you like to request?
+      description: Please provide the description of the feature you would like to request.
+      placeholder: <Description>
+    validations:
+      required: true
+  - type: textarea
+    id: additional-info
+    attributes:
+      label: Is there any additional information you would like to provide?
+      description: Please provide any additional information that you think might be useful.
+      placeholder: <Info>

--- a/.github/ISSUE_TEMPLATE/model-request.yml
+++ b/.github/ISSUE_TEMPLATE/model-request.yml
@@ -1,0 +1,22 @@
+name: Model
+description: Request a new model
+title: "[Model]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this report!
+  - type: textarea
+    id: model-name
+    attributes:
+      label: Which model would you like to support?
+      description: Please provide the name of the model you would like to see supported.
+      placeholder: Link to the model (e.g. on HuggingFace)
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: What are the main advantages of this model?
+      description: Please describe the main advantages of this model comparing to the existing ones and provide links to benchmarks if there are any.
+      placeholder: <Description>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+### All Submissions:
+
+* [ ] Have you followed the guidelines in our Contributing document?
+* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
+
+<!-- You can erase any parts of this template not applicable to your Pull Request. -->
+
+### New Feature Submissions:
+
+* [ ] Does your submission pass the existing tests?
+* [ ] Have you added tests for your feature?
+* [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?
+
+### New models submission:
+
+* [ ] Have you added an explanation of why it's important to include this model?
+* [ ] Have you added tests for the new model? Were canonical values for tests computed via the original model?
+* [ ] Have you added the code snippet for how canonical values were computed?
+* [ ] Have you successfully ran tests with your changes locally?


### PR DESCRIPTION
Previously we had only Bug/Model request template, which does not meet all the requirements
This PR suggests to decouple Bug/Model request template into two separate ones and introduces a feature request template as well as PR template.