### PR TITLE
Add rerankers to the list of supported models (Supported_Models.ipynb)

### DIFF
--- a/docs/examples/Supported_Models.ipynb
+++ b/docs/examples/Supported_Models.ipynb
@@ -2,29 +2,36 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:13:23.806907Z",
-     "start_time": "2024-05-31T18:13:23.797078Z"
+     "end_time": "2024-11-13T08:52:46.651285Z",
+     "start_time": "2024-11-13T08:52:46.633741Z"
     }
    },
-   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2"
-   ]
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n"
+     ]
+    }
+   ],
+   "execution_count": 3
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:14:31.147674Z",
-     "start_time": "2024-05-31T18:14:31.134015Z"
+     "end_time": "2024-11-13T08:52:46.973001Z",
+     "start_time": "2024-11-13T08:52:46.962113Z"
     }
    },
-   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -33,9 +40,11 @@
     "    TextEmbedding,\n",
     "    LateInteractionTextEmbedding,\n",
     "    ImageEmbedding,\n",
-    "    TextCrossEncoder,\n",
-    ")"
-   ]
+    ")\n",
+    "from fastembed.rerank.cross_encoder import TextCrossEncoder"
+   ],
+   "outputs": [],
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -46,16 +55,79 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:13:25.863008Z",
-     "start_time": "2024-05-31T18:13:25.837795Z"
+     "end_time": "2024-11-13T08:52:49.705020Z",
+     "start_time": "2024-11-13T08:52:49.665915Z"
     }
    },
+   "source": [
+    "supported_models = (\n",
+    "    pd.DataFrame(TextEmbedding.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\", \"additional_files\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")\n",
+    "supported_models"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                                                model   dim  \\\n",
+       "0                              BAAI/bge-small-en-v1.5   384   \n",
+       "1                              BAAI/bge-small-zh-v1.5   512   \n",
+       "2                 snowflake/snowflake-arctic-embed-xs   384   \n",
+       "3              sentence-transformers/all-MiniLM-L6-v2   384   \n",
+       "4                  jinaai/jina-embeddings-v2-small-en   512   \n",
+       "5                                   BAAI/bge-small-en   384   \n",
+       "6                  snowflake/snowflake-arctic-embed-s   384   \n",
+       "7                    nomic-ai/nomic-embed-text-v1.5-Q   768   \n",
+       "8                               BAAI/bge-base-en-v1.5   768   \n",
+       "9   sentence-transformers/paraphrase-multilingual-...   384   \n",
+       "10                          Qdrant/clip-ViT-B-32-text   512   \n",
+       "11                  jinaai/jina-embeddings-v2-base-de   768   \n",
+       "12                                   BAAI/bge-base-en   768   \n",
+       "13                 snowflake/snowflake-arctic-embed-m   768   \n",
+       "14                     nomic-ai/nomic-embed-text-v1.5   768   \n",
+       "15                  jinaai/jina-embeddings-v2-base-en   768   \n",
+       "16                       nomic-ai/nomic-embed-text-v1   768   \n",
+       "17            snowflake/snowflake-arctic-embed-m-long   768   \n",
+       "18                 mixedbread-ai/mxbai-embed-large-v1  1024   \n",
+       "19                jinaai/jina-embeddings-v2-base-code   768   \n",
+       "20  sentence-transformers/paraphrase-multilingual-...   768   \n",
+       "21                 snowflake/snowflake-arctic-embed-l  1024   \n",
+       "22                                 thenlper/gte-large  1024   \n",
+       "23                             BAAI/bge-large-en-v1.5  1024   \n",
+       "24                     intfloat/multilingual-e5-large  1024   \n",
+       "\n",
+       "                                          description     license  size_in_GB  \n",
+       "0   Text embeddings, Unimodal (text), English, 512...         mit       0.067  \n",
+       "1   Text embeddings, Unimodal (text), Chinese, 512...         mit       0.090  \n",
+       "2   Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.090  \n",
+       "3   Text embeddings, Unimodal (text), English, 256...  apache-2.0       0.090  \n",
+       "4   Text embeddings, Unimodal (text), English, 819...  apache-2.0       0.120  \n",
+       "5   Text embeddings, Unimodal (text), English, 512...         mit       0.130  \n",
+       "6   Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.130  \n",
+       "7   Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.130  \n",
+       "8   Text embeddings, Unimodal (text), English, 512...         mit       0.210  \n",
+       "9   Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.220  \n",
+       "10  Text embeddings, Multimodal (text&image), Engl...         mit       0.250  \n",
+       "11  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.320  \n",
+       "12  Text embeddings, Unimodal (text), English, 512...         mit       0.420  \n",
+       "13  Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.430  \n",
+       "14  Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.520  \n",
+       "15  Text embeddings, Unimodal (text), English, 819...  apache-2.0       0.520  \n",
+       "16  Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.520  \n",
+       "17  Text embeddings, Unimodal (text), English, 204...  apache-2.0       0.540  \n",
+       "18  Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.640  \n",
+       "19  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.640  \n",
+       "20  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       1.000  \n",
+       "21  Text embeddings, Unimodal (text), English, 512...  apache-2.0       1.020  \n",
+       "22  Text embeddings, Unimodal (text), English, 512...         mit       1.200  \n",
+       "23  Text embeddings, Unimodal (text), English, 512...         mit       1.200  \n",
+       "24  Text embeddings, Unimodal (text), Multilingual...         mit       2.240  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -286,77 +358,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                                model   dim  \\\n",
-       "0                              BAAI/bge-small-en-v1.5   384   \n",
-       "1                              BAAI/bge-small-zh-v1.5   512   \n",
-       "2                 snowflake/snowflake-arctic-embed-xs   384   \n",
-       "3              sentence-transformers/all-MiniLM-L6-v2   384   \n",
-       "4                  jinaai/jina-embeddings-v2-small-en   512   \n",
-       "5                                   BAAI/bge-small-en   384   \n",
-       "6                  snowflake/snowflake-arctic-embed-s   384   \n",
-       "7                    nomic-ai/nomic-embed-text-v1.5-Q   768   \n",
-       "8                               BAAI/bge-base-en-v1.5   768   \n",
-       "9   sentence-transformers/paraphrase-multilingual-...   384   \n",
-       "10                          Qdrant/clip-ViT-B-32-text   512   \n",
-       "11                  jinaai/jina-embeddings-v2-base-de   768   \n",
-       "12                                   BAAI/bge-base-en   768   \n",
-       "13                 snowflake/snowflake-arctic-embed-m   768   \n",
-       "14                     nomic-ai/nomic-embed-text-v1.5   768   \n",
-       "15                  jinaai/jina-embeddings-v2-base-en   768   \n",
-       "16                       nomic-ai/nomic-embed-text-v1   768   \n",
-       "17            snowflake/snowflake-arctic-embed-m-long   768   \n",
-       "18                 mixedbread-ai/mxbai-embed-large-v1  1024   \n",
-       "19                jinaai/jina-embeddings-v2-base-code   768   \n",
-       "20  sentence-transformers/paraphrase-multilingual-...   768   \n",
-       "21                 snowflake/snowflake-arctic-embed-l  1024   \n",
-       "22                                 thenlper/gte-large  1024   \n",
-       "23                             BAAI/bge-large-en-v1.5  1024   \n",
-       "24                     intfloat/multilingual-e5-large  1024   \n",
-       "\n",
-       "                                          description     license  size_in_GB  \n",
-       "0   Text embeddings, Unimodal (text), English, 512...         mit       0.067  \n",
-       "1   Text embeddings, Unimodal (text), Chinese, 512...         mit       0.090  \n",
-       "2   Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.090  \n",
-       "3   Text embeddings, Unimodal (text), English, 256...  apache-2.0       0.090  \n",
-       "4   Text embeddings, Unimodal (text), English, 819...  apache-2.0       0.120  \n",
-       "5   Text embeddings, Unimodal (text), English, 512...         mit       0.130  \n",
-       "6   Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.130  \n",
-       "7   Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.130  \n",
-       "8   Text embeddings, Unimodal (text), English, 512...         mit       0.210  \n",
-       "9   Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.220  \n",
-       "10  Text embeddings, Multimodal (text&image), Engl...         mit       0.250  \n",
-       "11  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.320  \n",
-       "12  Text embeddings, Unimodal (text), English, 512...         mit       0.420  \n",
-       "13  Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.430  \n",
-       "14  Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.520  \n",
-       "15  Text embeddings, Unimodal (text), English, 819...  apache-2.0       0.520  \n",
-       "16  Text embeddings, Multimodal (text, image), Eng...  apache-2.0       0.520  \n",
-       "17  Text embeddings, Unimodal (text), English, 204...  apache-2.0       0.540  \n",
-       "18  Text embeddings, Unimodal (text), English, 512...  apache-2.0       0.640  \n",
-       "19  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       0.640  \n",
-       "20  Text embeddings, Unimodal (text), Multilingual...  apache-2.0       1.000  \n",
-       "21  Text embeddings, Unimodal (text), English, 512...  apache-2.0       1.020  \n",
-       "22  Text embeddings, Unimodal (text), English, 512...         mit       1.200  \n",
-       "23  Text embeddings, Unimodal (text), English, 512...         mit       1.200  \n",
-       "24  Text embeddings, Unimodal (text), Multilingual...         mit       2.240  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "supported_models = (\n",
-    "    pd.DataFrame(TextEmbedding.list_supported_models())\n",
-    "    .sort_values(\"size_in_GB\")\n",
-    "    .drop(columns=[\"sources\", \"model_file\", \"additional_files\"])\n",
-    "    .reset_index(drop=True)\n",
-    ")\n",
-    "supported_models"
-   ]
+   "execution_count": 5
   },
   {
    "cell_type": "markdown",
@@ -367,16 +376,42 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:13:27.124747Z",
-     "start_time": "2024-05-31T18:13:27.096212Z"
+     "end_time": "2024-11-13T08:52:51.690851Z",
+     "start_time": "2024-11-13T08:52:51.677404Z"
     }
    },
+   "source": [
+    "(\n",
+    "    pd.DataFrame(SparseTextEmbedding.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\", \"additional_files\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                                     model  vocab_size  \\\n",
+       "0                              Qdrant/bm25         NaN   \n",
+       "1  Qdrant/bm42-all-minilm-l6-v2-attentions     30522.0   \n",
+       "2               prithivida/Splade_PP_en_v1     30522.0   \n",
+       "3                prithvida/Splade_PP_en_v1     30522.0   \n",
+       "\n",
+       "                                         description     license  size_in_GB  \\\n",
+       "0  BM25 as sparse embeddings meant to be used wit...  apache-2.0       0.010   \n",
+       "1  Light sparse embedding model, which assigns an...  apache-2.0       0.090   \n",
+       "2  Independent Implementation of SPLADE++ Model f...  apache-2.0       0.532   \n",
+       "3  Independent Implementation of SPLADE++ Model f...  apache-2.0       0.532   \n",
+       "\n",
+       "  requires_idf  \n",
+       "0         True  \n",
+       "1         True  \n",
+       "2          NaN  \n",
+       "3          NaN  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -444,40 +479,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                     model  vocab_size  \\\n",
-       "0                              Qdrant/bm25         NaN   \n",
-       "1  Qdrant/bm42-all-minilm-l6-v2-attentions     30522.0   \n",
-       "2               prithivida/Splade_PP_en_v1     30522.0   \n",
-       "3                prithvida/Splade_PP_en_v1     30522.0   \n",
-       "\n",
-       "                                         description     license  size_in_GB  \\\n",
-       "0  BM25 as sparse embeddings meant to be used wit...  apache-2.0       0.010   \n",
-       "1  Light sparse embedding model, which assigns an...  apache-2.0       0.090   \n",
-       "2  Independent Implementation of SPLADE++ Model f...  apache-2.0       0.532   \n",
-       "3  Independent Implementation of SPLADE++ Model f...  apache-2.0       0.532   \n",
-       "\n",
-       "  requires_idf  \n",
-       "0         True  \n",
-       "1         True  \n",
-       "2          NaN  \n",
-       "3          NaN  "
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "(\n",
-    "    pd.DataFrame(SparseTextEmbedding.list_supported_models())\n",
-    "    .sort_values(\"size_in_GB\")\n",
-    "    .drop(columns=[\"sources\", \"model_file\", \"additional_files\"])\n",
-    "    .reset_index(drop=True)\n",
-    ")"
-   ]
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -490,17 +499,40 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "metadata": {
+    "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:14:34.370252Z",
-     "start_time": "2024-05-31T18:14:34.354270Z"
-    },
-    "collapsed": false
+     "end_time": "2024-11-13T08:52:52.866135Z",
+     "start_time": "2024-11-13T08:52:52.852411Z"
+    }
    },
+   "source": [
+    "(\n",
+    "    pd.DataFrame(LateInteractionTextEmbedding.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                                   model  dim  \\\n",
+       "0  answerdotai/answerai-colbert-small-v1   96   \n",
+       "1                 colbert-ir/colbertv2.0  128   \n",
+       "2                 jinaai/jina-colbert-v2  128   \n",
+       "\n",
+       "                                         description       license  \\\n",
+       "0  Text embeddings, Unimodal (text), Multilingual...    apache-2.0   \n",
+       "1                             Late interaction model           mit   \n",
+       "2  New model that expands capabilities of colbert...  cc-by-nc-4.0   \n",
+       "\n",
+       "   size_in_GB        additional_files  \n",
+       "0        0.13                     NaN  \n",
+       "1        0.44                     NaN  \n",
+       "2        2.24  [onnx/model.onnx_data]  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -525,6 +557,7 @@
        "      <th>description</th>\n",
        "      <th>license</th>\n",
        "      <th>size_in_GB</th>\n",
+       "      <th>additional_files</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -535,6 +568,7 @@
        "      <td>Text embeddings, Unimodal (text), Multilingual...</td>\n",
        "      <td>apache-2.0</td>\n",
        "      <td>0.13</td>\n",
+       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -543,34 +577,28 @@
        "      <td>Late interaction model</td>\n",
        "      <td>mit</td>\n",
        "      <td>0.44</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>jinaai/jina-colbert-v2</td>\n",
+       "      <td>128</td>\n",
+       "      <td>New model that expands capabilities of colbert...</td>\n",
+       "      <td>cc-by-nc-4.0</td>\n",
+       "      <td>2.24</td>\n",
+       "      <td>[onnx/model.onnx_data]</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                                   model  dim  \\\n",
-       "0  answerdotai/answerai-colbert-small-v1   96   \n",
-       "1                 colbert-ir/colbertv2.0  128   \n",
-       "\n",
-       "                                         description     license  size_in_GB  \n",
-       "0  Text embeddings, Unimodal (text), Multilingual...  apache-2.0        0.13  \n",
-       "1                             Late interaction model         mit        0.44  "
       ]
      },
-     "execution_count": 5,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "(\n",
-    "    pd.DataFrame(LateInteractionTextEmbedding.list_supported_models())\n",
-    "    .sort_values(\"size_in_GB\")\n",
-    "    .drop(columns=[\"sources\", \"model_file\"])\n",
-    "    .reset_index(drop=True)\n",
-    ")"
-   ]
+   "execution_count": 7
   },
   {
    "cell_type": "markdown",
@@ -583,17 +611,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "metadata": {
+    "collapsed": false,
     "ExecuteTime": {
-     "end_time": "2024-05-31T18:14:42.501881Z",
-     "start_time": "2024-05-31T18:14:42.484726Z"
-    },
-    "collapsed": false
+     "end_time": "2024-11-13T08:52:54.060642Z",
+     "start_time": "2024-11-13T08:52:54.043437Z"
+    }
    },
+   "source": [
+    "(\n",
+    "    pd.DataFrame(ImageEmbedding.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                         model   dim  \\\n",
+       "0         Qdrant/resnet50-onnx  2048   \n",
+       "1  Qdrant/clip-ViT-B-32-vision   512   \n",
+       "2       Qdrant/Unicom-ViT-B-32   512   \n",
+       "3       Qdrant/Unicom-ViT-B-16   768   \n",
+       "\n",
+       "                                         description     license  size_in_GB  \n",
+       "0      Image embeddings, Unimodal (image), 2016 year  apache-2.0        0.10  \n",
+       "1  Image embeddings, Multimodal (text&image), 202...         mit        0.34  \n",
+       "2  Image embeddings, Multimodal (text&image), 202...  apache-2.0        0.48  \n",
+       "3  Image embeddings (more detailed than Unicom-Vi...  apache-2.0        0.82  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -656,34 +704,14 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                         model   dim  \\\n",
-       "0         Qdrant/resnet50-onnx  2048   \n",
-       "1  Qdrant/clip-ViT-B-32-vision   512   \n",
-       "2       Qdrant/Unicom-ViT-B-32   512   \n",
-       "3       Qdrant/Unicom-ViT-B-16   768   \n",
-       "\n",
-       "                                         description     license  size_in_GB  \n",
-       "0      Image embeddings, Unimodal (image), 2016 year  apache-2.0        0.10  \n",
-       "1  Image embeddings, Multimodal (text&image), 202...         mit        0.34  \n",
-       "2  Image embeddings, Multimodal (text&image), 202...  apache-2.0        0.48  \n",
-       "3  Image embeddings (more detailed than Unicom-Vi...  apache-2.0        0.82  "
       ]
      },
-     "execution_count": 6,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "(\n",
-    "    pd.DataFrame(ImageEmbedding.list_supported_models())\n",
-    "    .sort_values(\"size_in_GB\")\n",
-    "    .drop(columns=[\"sources\", \"model_file\"])\n",
-    "    .reset_index(drop=True)\n",
-    ")"
-   ]
+   "execution_count": 8
   },
   {
    "cell_type": "markdown",
@@ -694,11 +722,34 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-11-13T08:52:55.933033Z",
+     "start_time": "2024-11-13T08:52:55.915572Z"
+    }
+   },
+   "source": [
+    "(\n",
+    "    pd.DataFrame(TextCrossEncoder.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ],
    "outputs": [
     {
      "data": {
+      "text/plain": [
+       "                            model  size_in_GB  \\\n",
+       "0   Xenova/ms-marco-MiniLM-L-6-v2        0.08   \n",
+       "1  Xenova/ms-marco-MiniLM-L-12-v2        0.12   \n",
+       "2          BAAI/bge-reranker-base        1.04   \n",
+       "\n",
+       "                                         description     license  \n",
+       "0  MiniLM-L-6-v2 model optimized for re-ranking t...  apache-2.0  \n",
+       "1  MiniLM-L-12-v2 model optimized for re-ranking ...  apache-2.0  \n",
+       "2  BGE reranker base model for cross-encoder re-r...         mit  "
+      ],
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -749,32 +800,21 @@
        "  </tbody>\n",
        "</table>\n",
        "</div>"
-      ],
-      "text/plain": [
-       "                            model  size_in_GB  \\\n",
-       "0   Xenova/ms-marco-MiniLM-L-6-v2        0.08   \n",
-       "1  Xenova/ms-marco-MiniLM-L-12-v2        0.12   \n",
-       "2          BAAI/bge-reranker-base        1.04   \n",
-       "\n",
-       "                                         description     license  \n",
-       "0  MiniLM-L-6-v2 model optimized for re-ranking t...  apache-2.0  \n",
-       "1  MiniLM-L-12-v2 model optimized for re-ranking ...  apache-2.0  \n",
-       "2  BGE reranker base model for cross-encoder re-r...         mit  "
       ]
      },
-     "execution_count": 12,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
-   "source": [
-    "(\n",
-    "    pd.DataFrame(TextCrossEncoder.list_supported_models())\n",
-    "    .sort_values(\"size_in_GB\")\n",
-    "    .drop(columns=[\"sources\", \"model_file\"])\n",
-    "    .reset_index(drop=True)\n",
-    ")"
-   ]
+   "execution_count": 9
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": ""
   }
  ],
  "metadata": {

--- a/docs/examples/Supported_Models.ipynb
+++ b/docs/examples/Supported_Models.ipynb
@@ -24,16 +24,7 @@
      "start_time": "2024-05-31T18:14:31.134015Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/hossam/.pyenv/versions/.venv/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -42,6 +33,7 @@
     "    TextEmbedding,\n",
     "    LateInteractionTextEmbedding,\n",
     "    ImageEmbedding,\n",
+    "    TextCrossEncoder,\n",
     ")"
    ]
   },
@@ -533,7 +525,6 @@
        "      <th>description</th>\n",
        "      <th>license</th>\n",
        "      <th>size_in_GB</th>\n",
-       "      <th>additional_files</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -544,7 +535,6 @@
        "      <td>Text embeddings, Unimodal (text), Multilingual...</td>\n",
        "      <td>apache-2.0</td>\n",
        "      <td>0.13</td>\n",
-       "      <td>NaN</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -553,36 +543,19 @@
        "      <td>Late interaction model</td>\n",
        "      <td>mit</td>\n",
        "      <td>0.44</td>\n",
-       "      <td>NaN</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>jinaai/jina-colbert-v2</td>\n",
-       "      <td>1024</td>\n",
-       "      <td>New model that expands capabilities of colbert...</td>\n",
-       "      <td>cc-by-nc-4.0</td>\n",
-       "      <td>2.24</td>\n",
-       "      <td>[onnx/model.onnx_data]</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                                   model   dim  \\\n",
-       "0  answerdotai/answerai-colbert-small-v1    96   \n",
-       "1                 colbert-ir/colbertv2.0   128   \n",
-       "2                 jinaai/jina-colbert-v2  1024   \n",
+       "                                   model  dim  \\\n",
+       "0  answerdotai/answerai-colbert-small-v1   96   \n",
+       "1                 colbert-ir/colbertv2.0  128   \n",
        "\n",
-       "                                         description       license  \\\n",
-       "0  Text embeddings, Unimodal (text), Multilingual...    apache-2.0   \n",
-       "1                             Late interaction model           mit   \n",
-       "2  New model that expands capabilities of colbert...  cc-by-nc-4.0   \n",
-       "\n",
-       "   size_in_GB        additional_files  \n",
-       "0        0.13                     NaN  \n",
-       "1        0.44                     NaN  \n",
-       "2        2.24  [onnx/model.onnx_data]  "
+       "                                         description     license  size_in_GB  \n",
+       "0  Text embeddings, Unimodal (text), Multilingual...  apache-2.0        0.13  \n",
+       "1                             Late interaction model         mit        0.44  "
       ]
      },
      "execution_count": 5,
@@ -711,6 +684,97 @@
     "    .reset_index(drop=True)\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Supported Rerankers Models"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>size_in_GB</th>\n",
+       "      <th>description</th>\n",
+       "      <th>license</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Xenova/ms-marco-MiniLM-L-6-v2</td>\n",
+       "      <td>0.08</td>\n",
+       "      <td>MiniLM-L-6-v2 model optimized for re-ranking t...</td>\n",
+       "      <td>apache-2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>Xenova/ms-marco-MiniLM-L-12-v2</td>\n",
+       "      <td>0.12</td>\n",
+       "      <td>MiniLM-L-12-v2 model optimized for re-ranking ...</td>\n",
+       "      <td>apache-2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>BAAI/bge-reranker-base</td>\n",
+       "      <td>1.04</td>\n",
+       "      <td>BGE reranker base model for cross-encoder re-r...</td>\n",
+       "      <td>mit</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            model  size_in_GB  \\\n",
+       "0   Xenova/ms-marco-MiniLM-L-6-v2        0.08   \n",
+       "1  Xenova/ms-marco-MiniLM-L-12-v2        0.12   \n",
+       "2          BAAI/bge-reranker-base        1.04   \n",
+       "\n",
+       "                                         description     license  \n",
+       "0  MiniLM-L-6-v2 model optimized for re-ranking t...  apache-2.0  \n",
+       "1  MiniLM-L-12-v2 model optimized for re-ranking ...  apache-2.0  \n",
+       "2  BGE reranker base model for cross-encoder re-r...         mit  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(\n",
+    "    pd.DataFrame(TextCrossEncoder.list_supported_models())\n",
+    "    .sort_values(\"size_in_GB\")\n",
+    "    .drop(columns=[\"sources\", \"model_file\"])\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ]
   }
  ],
  "metadata": {
@@ -729,7 +793,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.15"
+   "version": "3.11.2"
   },
   "orig_nbformat": 4
  },

--- a/fastembed/__init__.py
+++ b/fastembed/__init__.py
@@ -4,7 +4,6 @@ from fastembed.image import ImageEmbedding
 from fastembed.late_interaction import LateInteractionTextEmbedding
 from fastembed.sparse import SparseEmbedding, SparseTextEmbedding
 from fastembed.text import TextEmbedding
-from fastembed.rerank.cross_encoder import TextCrossEncoder
 
 try:
     version = importlib.metadata.version("fastembed")
@@ -18,5 +17,4 @@ __all__ = [
     "SparseEmbedding",
     "ImageEmbedding",
     "LateInteractionTextEmbedding",
-    "TextCrossEncoder",
 ]

--- a/fastembed/__init__.py
+++ b/fastembed/__init__.py
@@ -4,6 +4,7 @@ from fastembed.image import ImageEmbedding
 from fastembed.late_interaction import LateInteractionTextEmbedding
 from fastembed.sparse import SparseEmbedding, SparseTextEmbedding
 from fastembed.text import TextEmbedding
+from fastembed.rerank.cross_encoder import TextCrossEncoder
 
 try:
     version = importlib.metadata.version("fastembed")
@@ -17,4 +18,5 @@ __all__ = [
     "SparseEmbedding",
     "ImageEmbedding",
     "LateInteractionTextEmbedding",
+    "TextCrossEncoder",
 ]


### PR DESCRIPTION
Reranker models are not listed on https://qdrant.github.io/fastembed/examples/Supported_Models/

I added them at the end.
I had to add TextCrossEncoder to fastembed/__init__.py. I don't know if that's the best way to do this

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

