### PR TITLE
fix: fix model cleanup in tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest -s -vv -l tests/test_late_interaction_embeddings.py
+          poetry run pytest 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest -s -vv -l
+          poetry run pytest -s -vv -l tests/test_late_interaction_embeddings.py

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest
+          poetry run pytest -s -vv -l

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -42,4 +42,4 @@ jobs:
 
       - name: Run pytest
         run: |
-          poetry run pytest -s -vv -l tests/test_late_interaction_embeddings.py
+          poetry run pytest -s -vv -l

--- a/tests/test_attention_embeddings.py
+++ b/tests/test_attention_embeddings.py
@@ -1,10 +1,10 @@
 import os
-import shutil
 
 import numpy as np
 import pytest
 
 from fastembed import SparseTextEmbedding
+from tests.utils import delete_model_cache
 
 
 @pytest.mark.parametrize("model_name", ["Qdrant/bm42-all-minilm-l6-v2-attentions", "Qdrant/bm25"])
@@ -67,7 +67,7 @@ def test_attention_embeddings(model_name):
         assert len(result.indices) == 2
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize("model_name", ["Qdrant/bm42-all-minilm-l6-v2-attentions", "Qdrant/bm25"])
@@ -92,7 +92,7 @@ def test_parallel_processing(model_name):
         assert np.allclose(emb_1.values, emb_3.values)
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize("model_name", ["Qdrant/bm25"])
@@ -118,7 +118,7 @@ def test_multilanguage(model_name):
     assert embeddings[1].indices.shape == (4,)
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize("model_name", ["Qdrant/bm25"])
@@ -141,7 +141,7 @@ def test_special_characters(model_name):
         assert embeddings[idx].indices.shape == (shape,)
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize("model_name", ["Qdrant/bm42-all-minilm-l6-v2-attentions"])

--- a/tests/test_late_interaction_embeddings.py
+++ b/tests/test_late_interaction_embeddings.py
@@ -1,5 +1,4 @@
 import os
-import shutil
 
 import pytest
 import numpy as np
@@ -7,6 +6,7 @@ import numpy as np
 from fastembed.late_interaction.late_interaction_text_embedding import (
     LateInteractionTextEmbedding,
 )
+from tests.utils import delete_model_cache
 
 # vectors are abridged and rounded for brevity
 CANONICAL_COLUMN_VALUES = {
@@ -167,7 +167,7 @@ def test_batch_embedding():
             assert np.allclose(value[:, :abridged_dim], expected_result, atol=2e-3)
 
         if is_ci:
-            shutil.rmtree(model.model._model_dir)
+            delete_model_cache(model.model._model_dir)
 
 
 def test_single_embedding():
@@ -182,7 +182,7 @@ def test_single_embedding():
         assert np.allclose(result[:, :abridged_dim], expected_result, atol=2e-3)
 
         if is_ci:
-            shutil.rmtree(model.model._model_dir)
+            delete_model_cache(model.model._model_dir)
 
 
 def test_single_embedding_query():
@@ -197,7 +197,7 @@ def test_single_embedding_query():
         assert np.allclose(result[:, :abridged_dim], expected_result, atol=2e-3)
 
         if is_ci:
-            shutil.rmtree(model.model._model_dir)
+            delete_model_cache(model.model._model_dir)
 
 
 def test_parallel_processing():
@@ -219,7 +219,7 @@ def test_parallel_processing():
     assert np.allclose(embeddings, embeddings_3, atol=1e-3)
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize(
@@ -227,6 +227,8 @@ def test_parallel_processing():
     ["colbert-ir/colbertv2.0"],
 )
 def test_lazy_load(model_name):
+    is_ci = os.getenv("CI")
+
     model = LateInteractionTextEmbedding(model_name=model_name, lazy_load=True)
     assert not hasattr(model.model, "model")
 
@@ -239,3 +241,6 @@ def test_lazy_load(model_name):
 
     model = LateInteractionTextEmbedding(model_name=model_name, lazy_load=True)
     list(model.passage_embed(docs))
+
+    if is_ci:
+        delete_model_cache(model.model._model_dir)

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -1,10 +1,10 @@
 import os
-import shutil
 
 import numpy as np
 import pytest
 
 from fastembed.text.text_embedding import TextEmbedding
+from tests.utils import delete_model_cache
 
 CANONICAL_VECTOR_VALUES = {
     "BAAI/bge-small-en": np.array([-0.0232, -0.0255, 0.0174, -0.0639, -0.0006]),
@@ -85,7 +85,7 @@ def test_embedding():
             embeddings[0, : canonical_vector.shape[0]], canonical_vector, atol=1e-3
         ), model_desc["model"]
         if is_ci:
-            shutil.rmtree(model.model._model_dir)
+            delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize(
@@ -102,7 +102,7 @@ def test_batch_embedding(n_dims, model_name):
 
     assert embeddings.shape == (200, n_dims)
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize(
@@ -128,7 +128,7 @@ def test_parallel_processing(n_dims, model_name):
     assert np.allclose(embeddings, embeddings_3, atol=1e-3)
 
     if is_ci:
-        shutil.rmtree(model.model._model_dir)
+        delete_model_cache(model.model._model_dir)
 
 
 @pytest.mark.parametrize(
@@ -136,6 +136,7 @@ def test_parallel_processing(n_dims, model_name):
     ["BAAI/bge-small-en-v1.5"],
 )
 def test_lazy_load(model_name):
+    is_ci = os.getenv("CI")
     model = TextEmbedding(model_name=model_name, lazy_load=True)
     assert not hasattr(model.model, "model")
     docs = ["hello world", "flag embedding"]
@@ -147,3 +148,6 @@ def test_lazy_load(model_name):
 
     model = TextEmbedding(model_name=model_name, lazy_load=True)
     list(model.passage_embed(docs))
+
+    if is_ci:
+        delete_model_cache(model.model._model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,6 +31,9 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
             p = Path(path)
             if p.parent.exists() and p.parent.is_dir():
                 print("parent content: ", list(p.parent.iterdir()))
+                for q in p.parent.iterdir():
+                    if q.is_dir():
+                        print("content of dir", q, list(q.iterdir()))
             os.chmod(str(path), mode)
 
             # If the path is a directory, recursively apply chmod to its contents
@@ -61,5 +64,11 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     if model_dir.parent.parent.name.startswith("models--"):
         model_dir = model_dir.parent.parent
 
+    parent = model_dir.parent
     if model_dir.exists():
         shutil.rmtree(model_dir, onerror=on_error)
+    print("Parent was: ", parent)
+    print(list(parent.iterdir()))
+    for p in parent.iterdir():
+        if p.is_dir():
+            print("content of parent", p, list(p.iterdir()))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -36,12 +36,16 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
 
     def on_error(func, path, exc_info):
         exc_type, exc_value, exc_traceback = exc_info
+
         # Example usage:
         # Change permissions to 755 recursively for a directory
+        def last_resort(func, path, exc_info):
+            print("Failed to remove: ", path)
+            print("Exception: ", exc_value)
+            print("Traceback: ", traceback.format_tb(exc_traceback))
+
         recursive_chmod(path, 0o755)
-        print("Failed to remove: ", path)
-        print("Exception: ", exc_value)
-        print("Traceback: ", traceback.format_tb(exc_traceback))
+        shutil.rmtree(model_dir, onerror=last_resort)
 
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,48 +15,11 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     Args:
         model_dir (Union[str, Path]): The path to the model cache directory.
     """
-    import os
-
-    def recursive_chmod(path: str, mode: int):
-        """
-        Recursively change permissions of files and directories.
-
-        :param path: Path to the file or directory.
-        :param mode: File mode (e.g., 0o755).
-        """
-        # Change the permission of the current path
-        print("change permission", path, mode)
-        if os.path.exists(str(path)):
-            print("path exist", path)
-            p = Path(path)
-            if p.parent.exists() and p.parent.is_dir():
-                print("parent content: ", list(p.parent.iterdir()))
-                for q in p.parent.iterdir():
-                    if q.is_dir():
-                        print("content of dir", q, list(q.iterdir()))
-            os.chmod(str(path), mode)
-
-            # If the path is a directory, recursively apply chmod to its contents
-            if os.path.isdir(str(path)):
-                for entry in os.listdir(str(path)):
-                    full_path = os.path.join(str(path), entry)
-                    recursive_chmod(full_path, mode)
 
     def on_error(func, path, exc_info):
-        if not Path(path).exists():
-            print("path does not exist", path)
-            return
-        exc_type, exc_value, exc_traceback = exc_info
-
-        # Example usage:
-        # Change permissions to 755 recursively for a directory
-        def last_resort(func, path, exc_info):
-            print("Failed to remove: ", path)
-            print("Exception: ", exc_value)
-            print("Traceback: ", traceback.format_tb(exc_traceback))
-
-        recursive_chmod(path, 0o777)
-        shutil.rmtree(path, onerror=last_resort)
+        print("Failed to remove: ", path)
+        print("Exception: ", exc_info)
+        traceback.print_exception(*exc_info)
 
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)
@@ -64,39 +27,5 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     if model_dir.parent.parent.name.startswith("models--"):
         model_dir = model_dir.parent.parent
 
-    parent = model_dir.parent
     if model_dir.exists():
         shutil.rmtree(model_dir, onerror=on_error)
-    print("Parent was: ", parent)
-    print(list(parent.iterdir()))
-    for p in parent.iterdir():
-        if p.is_dir():
-            print("content of parent", p, list(p.iterdir()))
-
-    import sys
-    import stat
-
-    def get_size(path: Path) -> int:
-        if path.is_file():
-            return path.stat().st_size
-        elif path.is_dir():
-            # Sum up the sizes of all files in the directory
-            return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
-        return 0
-
-    def get_permissions(path: Path) -> str:
-        mode = path.stat().st_mode
-        return stat.filemode(mode)
-
-    try:
-        print(sys.getwindowsversion())
-        path = Path("C:/Users/RUNNER~1/AppData/Local/Temp/fastembed_cache/")
-        if path.exists():
-            for path in path.rglob("*"):
-                print(path)
-                size = get_size(path)
-                print(f"{path}: {size / (1024 * 1024):.2f} MB")
-                permissions = get_permissions(path)
-                print(f"{permissions} {path}")
-    except Exception:
-        print("Not windows")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,4 +21,13 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         model_dir = model_dir.parent.parent
 
     if model_dir.exists():
-        shutil.rmtree(model_dir)
+        try:
+            shutil.rmtree(model_dir)
+        except PermissionError as e:
+            print(e)
+            print("sleeping for 3 seconds...")
+            import time
+
+            time.sleep(3)
+            print("trying out again")
+            shutil.rmtree(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,11 +23,16 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     if model_dir.exists():
         try:
             shutil.rmtree(model_dir)
-        except PermissionError as e:
+        except Exception as e:
             print(e)
             print("sleeping for 3 seconds...")
             import time
 
             time.sleep(3)
             print("trying out again")
-            shutil.rmtree(model_dir)
+
+            if model_dir.exists():
+                # shutil.rmtree(model_dir)
+                shutil.rmtree(model_dir / "refs")
+                shutil.rmtree(model_dir / "snapshots")
+                shutil.rmtree(model_dir / "blobs")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,14 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         """
         # Change the permission of the current path
         print("change permission", path, mode)
-        os.chmod(str(path), mode)
+        try:
+            os.chmod(str(path), mode)
+        except Exception:
+            p = Path(path)
+            print(p.exists())
+            print(p.parent)
+            print(list(p.parent.iterdir()))
+            raise
 
         # If the path is a directory, recursively apply chmod to its contents
         if os.path.isdir(str(path)):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -29,7 +29,7 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         if os.path.exists(str(path)):
             print("path does not exist", path)
             p = Path(path)
-            if p.parent.exists():
+            if p.parent.exists() and p.parent.is_dir():
                 print("parent content: ", list(p.iterdir()))
             os.chmod(str(path), mode)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,8 +23,8 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     if model_dir.exists():
         try:
             shutil.rmtree(model_dir)
-        except Exception as e:
-            print(e)
+        except Exception:
+            # print(e)
             print("sleeping for 3 seconds...")
             import time
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,7 +16,15 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     """
 
     def on_error(func, path, exc_info):
-        print(f"Failed to remove {path}. {exc_info}")
+        import stat
+        import os
+
+        # Is the error an access error?
+        if not os.access(path, os.W_OK):
+            os.chmod(path, stat.S_IWUSR)
+            func(path)
+        else:
+            raise
 
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -75,11 +75,21 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
 
     import sys
 
+    def get_size(path: Path) -> int:
+        if path.is_file():
+            return path.stat().st_size
+        elif path.is_dir():
+            # Sum up the sizes of all files in the directory
+            return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
+        return 0
+
     try:
         print(sys.getwindowsversion())
         path = Path("C:/Users/RUNNER~1/AppData/Local/Temp/fastembed_cache/")
         if path.exists():
             for path in path.rglob("*"):
                 print(path)
+                size = get_size(path)
+                print(f"{path}: {size / (1024 * 1024):.2f} MB")
     except Exception:
         print("Not windows")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,6 +14,10 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     Args:
         model_dir (Union[str, Path]): The path to the model cache directory.
     """
+
+    def on_error(func, path, exc_info):
+        print(f"Failed to remove {path}. {exc_info}")
+
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)
 
@@ -21,18 +25,4 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         model_dir = model_dir.parent.parent
 
     if model_dir.exists():
-        try:
-            shutil.rmtree(model_dir)
-        except Exception:
-            # print(e)
-            print("sleeping for 3 seconds...")
-            import time
-
-            time.sleep(3)
-            print("trying out again")
-
-            if model_dir.exists():
-                # shutil.rmtree(model_dir)
-                shutil.rmtree(model_dir / "refs")
-                shutil.rmtree(model_dir / "snapshots")
-                shutil.rmtree(model_dir / "blobs")
+        shutil.rmtree(model_dir, onerror=on_error)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -28,4 +28,5 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         model_dir = model_dir.parent.parent
 
     if model_dir.exists():
+        # todo: PermissionDenied is raised on blobs removal in Windows, with blobs > 2GB
         shutil.rmtree(model_dir, onerror=on_error)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,6 +74,7 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
             print("content of parent", p, list(p.iterdir()))
 
     import sys
+    import stat
 
     def get_size(path: Path) -> int:
         if path.is_file():
@@ -83,6 +84,10 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
             return sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
         return 0
 
+    def get_permissions(path: Path) -> str:
+        mode = path.stat().st_mode
+        return stat.filemode(mode)
+
     try:
         print(sys.getwindowsversion())
         path = Path("C:/Users/RUNNER~1/AppData/Local/Temp/fastembed_cache/")
@@ -91,5 +96,7 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
                 print(path)
                 size = get_size(path)
                 print(f"{path}: {size / (1024 * 1024):.2f} MB")
+                permissions = get_permissions(path)
+                print(f"{permissions} {path}")
     except Exception:
         print("Not windows")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,9 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
                     recursive_chmod(full_path, mode)
 
     def on_error(func, path, exc_info):
+        if not Path(path).exists():
+            print("path does not exist", path)
+            return
         exc_type, exc_value, exc_traceback = exc_info
 
         # Example usage:
@@ -50,7 +53,7 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
             print("Traceback: ", traceback.format_tb(exc_traceback))
 
         recursive_chmod(path, 0o755)
-        shutil.rmtree(model_dir, onerror=last_resort)
+        shutil.rmtree(path, onerror=last_resort)
 
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -55,7 +55,7 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
             print("Exception: ", exc_value)
             print("Traceback: ", traceback.format_tb(exc_traceback))
 
-        recursive_chmod(path, 0o755)
+        recursive_chmod(path, 0o777)
         shutil.rmtree(path, onerror=last_resort)
 
     if isinstance(model_dir, str):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,20 +26,18 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         """
         # Change the permission of the current path
         print("change permission", path, mode)
-        try:
-            os.chmod(str(path), mode)
-        except Exception:
+        if os.path.exists(str(path)):
+            print("path does not exist", path)
             p = Path(path)
-            print(p.exists())
-            print(p.parent)
-            print(list(p.parent.iterdir()))
-            raise
+            if p.parent.exists():
+                print("parent content: ", list(p.iterdir()))
+            os.chmod(str(path), mode)
 
-        # If the path is a directory, recursively apply chmod to its contents
-        if os.path.isdir(str(path)):
-            for entry in os.listdir(str(path)):
-                full_path = os.path.join(str(path), entry)
-                recursive_chmod(full_path, mode)
+            # If the path is a directory, recursively apply chmod to its contents
+            if os.path.isdir(str(path)):
+                for entry in os.listdir(str(path)):
+                    full_path = os.path.join(str(path), entry)
+                    recursive_chmod(full_path, mode)
 
     def on_error(func, path, exc_info):
         exc_type, exc_value, exc_traceback = exc_info

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,24 @@
+import shutil
+
+from pathlib import Path
+from typing import Union
+
+
+def delete_model_cache(model_dir: Union[str, Path]) -> None:
+    """Delete the model cache directory.
+
+    If a model was downloaded from the HuggingFace model hub, then _model_dir is the dir to snapshots, removing
+    it won't help to release the memory, because data is in blobs directory.
+    If a model was downloaded from GCS, then we can just remove model_dir
+
+    Args:
+        model_dir (Union[str, Path]): The path to the model cache directory.
+    """
+    if isinstance(model_dir, str):
+        model_dir = Path(model_dir)
+
+    if model_dir.parent.parent.name.startswith("models--"):
+        model_dir = model_dir.parent.parent
+
+    if model_dir.exists():
+        shutil.rmtree(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,12 +26,12 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         """
         # Change the permission of the current path
         print("change permission", path, mode)
-        os.chmod(path, mode)
+        os.chmod(str(path), mode)
 
         # If the path is a directory, recursively apply chmod to its contents
-        if os.path.isdir(path):
-            for entry in os.listdir(path):
-                full_path = os.path.join(path, entry)
+        if os.path.isdir(str(path)):
+            for entry in os.listdir(str(path)):
+                full_path = os.path.join(str(path), entry)
                 recursive_chmod(full_path, mode)
 
     def on_error(func, path, exc_info):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import shutil
+import traceback
 
 from pathlib import Path
 from typing import Union
@@ -16,15 +17,10 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     """
 
     def on_error(func, path, exc_info):
-        import stat
-        import os
-
-        # Is the error an access error?
-        if not os.access(path, os.W_OK):
-            os.chmod(path, stat.S_IWUSR)
-            func(path)
-        else:
-            raise
+        exc_type, exc_value, exc_traceback = exc_info
+        print("Failed to remove: ", path)
+        print("Exception: ", exc_value)
+        print("Traceback: ", traceback.format_tb(exc_traceback))
 
     if isinstance(model_dir, str):
         model_dir = Path(model_dir)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,3 +72,14 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     for p in parent.iterdir():
         if p.is_dir():
             print("content of parent", p, list(p.iterdir()))
+
+    import sys
+
+    try:
+        print(sys.getwindowsversion())
+        path = Path("C:/Users/RUNNER~1/AppData/Local/Temp/fastembed_cache/")
+        if path.exists():
+            for path in path.rglob("*"):
+                print(path)
+    except Exception:
+        print("Not windows")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,9 +15,30 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
     Args:
         model_dir (Union[str, Path]): The path to the model cache directory.
     """
+    import os
+
+    def recursive_chmod(path: str, mode: int):
+        """
+        Recursively change permissions of files and directories.
+
+        :param path: Path to the file or directory.
+        :param mode: File mode (e.g., 0o755).
+        """
+        # Change the permission of the current path
+        print("change permission", path, mode)
+        os.chmod(path, mode)
+
+        # If the path is a directory, recursively apply chmod to its contents
+        if os.path.isdir(path):
+            for entry in os.listdir(path):
+                full_path = os.path.join(path, entry)
+                recursive_chmod(full_path, mode)
 
     def on_error(func, path, exc_info):
         exc_type, exc_value, exc_traceback = exc_info
+        # Example usage:
+        # Change permissions to 755 recursively for a directory
+        recursive_chmod(path, 0o755)
         print("Failed to remove: ", path)
         print("Exception: ", exc_value)
         print("Traceback: ", traceback.format_tb(exc_traceback))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,10 +27,10 @@ def delete_model_cache(model_dir: Union[str, Path]) -> None:
         # Change the permission of the current path
         print("change permission", path, mode)
         if os.path.exists(str(path)):
-            print("path does not exist", path)
+            print("path exist", path)
             p = Path(path)
             if p.parent.exists() and p.parent.is_dir():
-                print("parent content: ", list(p.iterdir()))
+                print("parent content: ", list(p.parent.iterdir()))
             os.chmod(str(path), mode)
 
             # If the path is a directory, recursively apply chmod to its contents


### PR DESCRIPTION
We've recently observed consistent failures in our gpu branch CI, after conducting several experiments, I found out, that we're not properly cleaning up models cache.

If a model was downloaded from GCP, then everything works fine.
However, if a model was downloaded from HF hub, then `_model_dir` which we're passing is pointing to `snapshots` dir, rather than to the root model's dir, thus, instead of actual data, we're only deleting symlinks to the files, which is stored in `blobs`. It led to running out of disk space in our gpu CI.