### PR TITLE
new: add python 3.13 support

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,6 +18,7 @@ jobs:
           - '3.10.x'
           - '3.11.x'
           - '3.12.x'
+          - '3.13.x'
         os:
           - ubuntu-latest
           - macos-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,18 +11,24 @@ repository = "https://github.com/qdrant/fastembed"
 keywords = ["vector", "embedding", "neural", "search", "qdrant", "sentence-transformers"]
 
 [tool.poetry.dependencies]
-python = ">=3.9.0,<3.13"
-onnx = "^1.15.0"
-onnxruntime = ">=1.17.0,<1.20.0"
+python = ">=3.9.0"
+onnx = ">=1.15.0"
+numpy = [
+    { version = ">=1.21,<2.1.0", python = "<3.10" },
+    { version = ">=1.21", python = ">=3.10,<3.12" },
+    { version = ">=1.26", python = ">=3.12,<3.13" },
+    { version = ">=2.1.0", python = ">=3.13" }
+]
+onnxruntime = [
+    { version = ">=1.17.0,<1.20.0", python = "<3.10" },
+    { version = ">=1.17.0,!=1.20.0", python = ">=3.10,<3.13" },
+    { version = ">1.20.0", python = ">=3.13" }
+]
 tqdm = "^4.66"
 requests = "^2.31"
 tokenizers = ">=0.15,<1.0"
 huggingface-hub = ">=0.20,<1.0"
 loguru = "^0.7.2"
-numpy = [
-    { version = ">=1.21", python = "<3.12" },
-    { version = ">=1.26", python = ">=3.12" }
-]
 pillow = "^10.3.0"
 mmh3 = "^4.1.0"
 py-rust-stemmers = "^0.1.0"


### PR DESCRIPTION
Adds support to 3.13 which was released on October 7th.

`onnxruntime` has started supporting python 3.13 as of version 1.20.0, however, that version contains some bug which makes it impossible for us to use that version.

https://github.com/microsoft/onnxruntime/issues/22704
