### PR TITLE
fix: Fix colbert model shape mismatch

### DIFF
--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -102,9 +102,6 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
         return encoded
 
     def _tokenize_documents(self, documents: list[str]) -> list[Encoding]:
-        current_max_length = self.tokenizer.truncation["max_length"]
-        # ensure not to overflow after adding document-marker
-        self.tokenizer.enable_truncation(max_length=current_max_length - 1)
         encoded = self.tokenizer.encode_batch(documents)
         return encoded
 
@@ -194,6 +191,9 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[np.ndarray]):
             self.tokenizer.encode(symbol, add_special_tokens=False).ids[0]
             for symbol in string.punctuation
         }
+        current_max_length = self.tokenizer.truncation["max_length"]
+        # ensure not to overflow after adding document-marker
+        self.tokenizer.enable_truncation(max_length=current_max_length - 1)
 
     def embed(
         self,


### PR DESCRIPTION
We don't truncate the input when adding the document marker in late interaction models. Sometimes, the input exceeded the maximum length the onnx model can handle, the tokenizer by default truncates with the maximum configuration found inside the tokenizer_config. But we didn't make sure that we truncate after adding the marker token. Example, input length 600, max input size 512. The tokenizer will truncate at 512. We add the marker token (513) and onnx model will raise. Thus, I've updated the truncate with maximum_length -1 to not overflow the input to onnx model. 

ref: #407 
ref: #410 

### All Submissions:

* [ ] Have you followed the guidelines in our Contributing document?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [ ] Does your submission pass the existing tests?
* [ ] Have you added tests for your feature?
* [ ] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### New models submission:

* [ ] Have you added an explanation of why it's important to include this model?
* [ ] Have you added tests for the new model? Were canonical values for tests computed via the original model?
* [ ] Have you added the code snippet for how canonical values were computed?
* [ ] Have you successfully ran tests with your changes locally?
