### PR TITLE
new: allow mmh3<6.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ tokenizers = ">=0.15,<1.0"
 huggingface-hub = ">=0.20,<1.0"
 loguru = "^0.7.2"
 pillow = ">=10.3.0,<12.0.0"
-mmh3 = "^4.1.0"
+mmh3 = ">=4.1.0,<6.0.0"
 py-rust-stemmers = "^0.1.0"
 
 [tool.poetry.group.test.dependencies]


### PR DESCRIPTION
mmh3 < 5.0.0 does not have wheels for python3.13 and build them from source
it might be a problem on machines without gcc