### PR TITLE
improvement: remove redundant lowercase and punctuation checks

### DIFF
--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -237,12 +237,7 @@ class Bm25(SparseTextEmbeddingBase):
 
     def _stem(self, tokens: list[str]) -> list[str]:
         stemmed_tokens: list[str] = []
-        for token in tokens:
-            lower_token = token.lower()
-
-            if token in self.punctuation:
-                continue
-
+        for lower_token in tokens:
             if lower_token in self.stopwords:
                 continue
 


### PR DESCRIPTION
The _stem method performs unnecessary checks that are already handled upstream:
- Punctuation check: remove_non_alphanumeric() already removes all punctuation
- Lowercase conversion: SimpleTokenizer.tokenize() already converts to lowercase

These redundant operations can be safely removed without affecting functionality.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass the existing tests?
* [x] Have you added tests for your feature?
* [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### New models submission:

* [x] Have you added an explanation of why it's important to include this model?
* [x] Have you added tests for the new model? Were canonical values for tests computed via the original model?
* [x] Have you added the code snippet for how canonical values were computed?
* [x] Have you successfully ran tests with your changes locally?
