### PR TITLE
Add Snowflake Arctic Embed L v2.0 model

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -169,7 +169,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         model_file="onnx/model.onnx",
     ),
     DenseModelDescription(
-        model="Snowflake/snowflake-arctic-embed-l-v2.0",
+        model="snowflake/snowflake-arctic-embed-l-v2.0",
         dim=1024,
         tasks={
             "embedding": {
@@ -328,7 +328,7 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
             Iterable[NumpyArray]: Query embeddings
         """
         # Check if model has task-specific prefixes configured
-        if hasattr(self.model_description, "tasks") and self.model_description.tasks:
+        if self.model_description.tasks:
             embedding_task = self.model_description.tasks.get("embedding", {})
             query_prefix = embedding_task.get("query_prefix", "")
 
@@ -357,7 +357,7 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
             Iterable[NumpyArray]: Passage embeddings
         """
         # Check if model has task-specific prefixes configured
-        if hasattr(self.model_description, "tasks") and self.model_description.tasks:
+        if self.model_description.tasks:
             embedding_task = self.model_description.tasks.get("embedding", {})
             passage_prefix = embedding_task.get("passage_prefix", "")
 


### PR DESCRIPTION
## Summary

Add support for `Snowflake/snowflake-arctic-embed-l-v2.0`, a multilingual embedding model that improves upon the original Arctic Embed L model with expanded language support and longer context.

## Model Features

- **Dimensions**: 1024
- **Languages**: 74 languages (multilingual via XLM-RoBERTa)
- **Context Length**: 8192 tokens (vs 512 in v1)
- **Architecture**: Based on BAAI/bge-m3-retromae (XLM-RoBERTa)
- **Special Capabilities**: 
  - Supports Matryoshka learning for dimension truncation to 256 dims
  - Compatible with 4-bit quantization
  - Query prefix recommended: `query: `
- **License**: Apache 2.0
- **Model Size**: 2.27 GB (ONNX format with separate data file)

## Changes

- Added model configuration to `supported_onnx_models` list in `fastembed/text/onnx_embedding.py`
- Added canonical test vectors to `tests/test_text_onnx_embeddings.py`
- Model includes both `onnx/model.onnx` and `onnx/model.onnx_data` files

## Test Plan

- [x] Model loads successfully from HuggingFace
- [x] Embeddings generated with expected shape (batch_size, 1024)
- [x] Canonical vectors match within tolerance (atol=1e-3)
- [x] Model appears in list of supported models

## References

- HuggingFace: https://huggingface.co/Snowflake/snowflake-arctic-embed-l-v2.0
- Similar PR: #561

🤖 Generated with [Claude Code](https://claude.com/claude-code)