### PR TITLE
feat: add public tokenize method for TextEmbedding class

### DIFF
--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -83,29 +83,6 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[NumpyArray]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], is_doc: bool = True, **kwargs: Any) -> list[int]:
-        if not hasattr(self, "model") or self.model is None:
-            self.load_onnx_model()
-        counts: list[int] = []
-        if is_doc:
-            encoded = self._tokenize_documents(documents=documents)
-            assert self.pad_token_id is not None
-            for e in encoded:
-                counts.append(
-                    sum(
-                        1
-                        for tid in e.ids
-                        if tid not in self.skip_list and tid != self.pad_token_id
-                    )
-                )
-        else:
-            # query padding uses MASK token; exclude it from count
-            assert self.mask_token_id is not None
-            encoded = self._tokenize_query(query=next(iter(documents)))
-            for e in encoded:
-                counts.append(sum(1 for tid in e.ids if tid != self.mask_token_id))
-        return counts
-
     def _tokenize(
         self, documents: list[str], is_doc: bool = True, **kwargs: Any
     ) -> list[Encoding]:

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -80,11 +80,16 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[NumpyArray]):
         )
         return onnx_input
 
-    def tokenize(self, texts: list[str], is_doc: bool = True, **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self._tokenize(documents, **kwargs)
+
+    def _tokenize(
+        self, documents: list[str], is_doc: bool = True, **kwargs: Any
+    ) -> list[Encoding]:
         return (
-            self._tokenize_documents(documents=texts)
+            self._tokenize_documents(documents=documents)
             if is_doc
-            else self._tokenize_query(query=next(iter(texts)))
+            else self._tokenize_query(query=next(iter(documents)))
         )
 
     def _tokenize_query(self, query: str) -> list[Encoding]:

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -80,7 +80,7 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[NumpyArray]):
         )
         return onnx_input
 
-    def tokenize(self, documents: list[str], is_doc: bool = True, **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], is_doc: bool = True, **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         return (
             self._tokenize_documents(documents=documents)
             if is_doc

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -80,11 +80,11 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[NumpyArray]):
         )
         return onnx_input
 
-    def tokenize(self, documents: list[str], is_doc: bool = True, **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, texts: list[str], is_doc: bool = True, **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         return (
-            self._tokenize_documents(documents=documents)
+            self._tokenize_documents(documents=texts)
             if is_doc
-            else self._tokenize_query(query=next(iter(documents)))
+            else self._tokenize_query(query=next(iter(texts)))
         )
 
     def _tokenize_query(self, query: str) -> list[Encoding]:

--- a/fastembed/late_interaction/colbert.py
+++ b/fastembed/late_interaction/colbert.py
@@ -83,6 +83,29 @@ class Colbert(LateInteractionTextEmbeddingBase, OnnxTextModel[NumpyArray]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], is_doc: bool = True, **kwargs: Any) -> list[int]:
+        if not hasattr(self, "model") or self.model is None:
+            self.load_onnx_model()
+        counts: list[int] = []
+        if is_doc:
+            encoded = self._tokenize_documents(documents=documents)
+            assert self.pad_token_id is not None
+            for e in encoded:
+                counts.append(
+                    sum(
+                        1
+                        for tid in e.ids
+                        if tid not in self.skip_list and tid != self.pad_token_id
+                    )
+                )
+        else:
+            # query padding uses MASK token; exclude it from count
+            assert self.mask_token_id is not None
+            encoded = self._tokenize_query(query=next(iter(documents)))
+            for e in encoded:
+                counts.append(sum(1 for tid in e.ids if tid != self.mask_token_id))
+        return counts
+
     def _tokenize(
         self, documents: list[str], is_doc: bool = True, **kwargs: Any
     ) -> list[Encoding]:

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -21,7 +21,7 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -22,7 +22,7 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._embedding_size: Optional[int] = None
 
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        raise NotImplementedError()
+        raise NotImplementedError("Subclasses must implement this method.")
 
     def embed(
         self,

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -24,9 +24,6 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        raise NotImplementedError("Subclasses must implement this method.")
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -24,6 +24,9 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -21,7 +21,7 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/late_interaction/late_interaction_embedding_base.py
+++ b/fastembed/late_interaction/late_interaction_embedding_base.py
@@ -1,5 +1,7 @@
 from typing import Iterable, Optional, Union, Any
 
+from tokenizers import Encoding
+
 from fastembed.common.model_description import DenseModelDescription
 from fastembed.common.types import NumpyArray
 from fastembed.common.model_management import ModelManagement
@@ -18,6 +20,9 @@ class LateInteractionTextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        raise NotImplementedError()
 
     def embed(
         self,

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -129,9 +129,6 @@ class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
         """
         return self.model.tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        return self.model.token_count(documents, **kwargs)
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -116,18 +116,18 @@ class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
             )
         return embedding_size
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: List of strings to tokenize
+            documents: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        return self.model.tokenize(texts, **kwargs)
+        return self.model.tokenize(documents, **kwargs)
 
     def embed(
         self,

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 from dataclasses import asdict
 
+from tokenizers import Encoding
+
 from fastembed.common.model_description import DenseModelDescription
 from fastembed.common.types import NumpyArray
 from fastembed.common import OnnxProvider
@@ -113,6 +115,21 @@ class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
                 f"Available model names: {model_names}"
             )
         return embedding_size
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        """
+        Tokenize input texts using the model's tokenizer.
+
+        Args:
+            texts: String or list of strings to tokenize
+            **kwargs: Additional arguments passed to the tokenizer
+
+        Returns:
+            List of tokenizer Encodings
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return self.model.tokenize(texts, **kwargs)
 
     def embed(
         self,

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -116,19 +116,17 @@ class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
             )
         return embedding_size
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: String or list of strings to tokenize
+            texts: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if isinstance(texts, str):
-            texts = [texts]
         return self.model.tokenize(texts, **kwargs)
 
     def embed(

--- a/fastembed/late_interaction/late_interaction_text_embedding.py
+++ b/fastembed/late_interaction/late_interaction_text_embedding.py
@@ -129,6 +129,9 @@ class LateInteractionTextEmbedding(LateInteractionTextEmbeddingBase):
         """
         return self.model.tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        return self.model.token_count(documents, **kwargs)
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction/token_embeddings.py
+++ b/fastembed/late_interaction/token_embeddings.py
@@ -25,7 +25,7 @@ supported_token_embeddings_models = [
 ]
 
 
-class TokenEmbeddingsModel(OnnxTextEmbedding, LateInteractionTextEmbeddingBase):  # type: ignore[misc]
+class TokenEmbeddingsModel(OnnxTextEmbedding, LateInteractionTextEmbeddingBase):
     @classmethod
     def _list_supported_models(cls) -> list[DenseModelDescription]:
         """Lists the supported models.

--- a/fastembed/late_interaction/token_embeddings.py
+++ b/fastembed/late_interaction/token_embeddings.py
@@ -25,7 +25,7 @@ supported_token_embeddings_models = [
 ]
 
 
-class TokenEmbeddingsModel(OnnxTextEmbedding, LateInteractionTextEmbeddingBase):
+class TokenEmbeddingsModel(OnnxTextEmbedding, LateInteractionTextEmbeddingBase):  # type: ignore[misc]
     @classmethod
     def _list_supported_models(cls) -> list[DenseModelDescription]:
         """Lists the supported models.

--- a/fastembed/late_interaction_multimodal/colpali.py
+++ b/fastembed/late_interaction_multimodal/colpali.py
@@ -160,9 +160,12 @@ class ColPali(LateInteractionMultimodalEmbeddingBase, OnnxMultimodalModel[NumpyA
         """
         return output.model_output
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self._tokenize(documents, **kwargs)
+
+    def _tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         texts_query: list[str] = []
-        for query in texts:
+        for query in documents:
             query = self.BOS_TOKEN + self.QUERY_PREFIX + query + self.PAD_TOKEN * 10
             query += "\n"
 

--- a/fastembed/late_interaction_multimodal/colpali.py
+++ b/fastembed/late_interaction_multimodal/colpali.py
@@ -163,16 +163,6 @@ class ColPali(LateInteractionMultimodalEmbeddingBase, OnnxMultimodalModel[NumpyA
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        encoded = self._tokenize(documents, **kwargs)
-        counts: list[int] = []
-        for e in encoded:
-            try:
-                counts.append(int(sum(e.attention_mask)))  # type: ignore[arg-type]
-            except Exception:
-                counts.append(len(e.ids))
-        return counts
-
     def _tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         texts_query: list[str] = []
         for query in documents:

--- a/fastembed/late_interaction_multimodal/colpali.py
+++ b/fastembed/late_interaction_multimodal/colpali.py
@@ -160,14 +160,15 @@ class ColPali(LateInteractionMultimodalEmbeddingBase, OnnxMultimodalModel[NumpyA
         """
         return output.model_output
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         texts_query: list[str] = []
         for query in documents:
             query = self.BOS_TOKEN + self.QUERY_PREFIX + query + self.PAD_TOKEN * 10
             query += "\n"
 
             texts_query.append(query)
-        encoded = self.tokenizer.encode_batch(texts_query)  # type: ignore[union-attr]
+        assert self.tokenizer is not None
+        encoded = self.tokenizer.encode_batch(texts_query)
         return encoded
 
     def _preprocess_onnx_text_input(

--- a/fastembed/late_interaction_multimodal/colpali.py
+++ b/fastembed/late_interaction_multimodal/colpali.py
@@ -163,6 +163,16 @@ class ColPali(LateInteractionMultimodalEmbeddingBase, OnnxMultimodalModel[NumpyA
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        encoded = self._tokenize(documents, **kwargs)
+        counts: list[int] = []
+        for e in encoded:
+            try:
+                counts.append(int(sum(e.attention_mask)))  # type: ignore[arg-type]
+            except Exception:
+                counts.append(len(e.ids))
+        return counts
+
     def _tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         texts_query: list[str] = []
         for query in documents:

--- a/fastembed/late_interaction_multimodal/colpali.py
+++ b/fastembed/late_interaction_multimodal/colpali.py
@@ -160,9 +160,9 @@ class ColPali(LateInteractionMultimodalEmbeddingBase, OnnxMultimodalModel[NumpyA
         """
         return output.model_output
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         texts_query: list[str] = []
-        for query in documents:
+        for query in texts:
             query = self.BOS_TOKEN + self.QUERY_PREFIX + query + self.PAD_TOKEN * 10
             query += "\n"
 

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
@@ -132,9 +132,6 @@ class LateInteractionMultimodalEmbedding(LateInteractionMultimodalEmbeddingBase)
         """
         return self.model.tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        return self.model.token_count(documents, **kwargs)
-
     def embed_text(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 from dataclasses import asdict
 
+from tokenizers import Encoding
+
 from fastembed.common import OnnxProvider, ImageInput
 from fastembed.common.types import NumpyArray
 from fastembed.late_interaction_multimodal.colpali import ColPali
@@ -116,6 +118,21 @@ class LateInteractionMultimodalEmbedding(LateInteractionMultimodalEmbeddingBase)
                 f"Available model names: {model_names}"
             )
         return embedding_size
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        """
+        Tokenize input texts using the model's tokenizer.
+
+        Args:
+            texts: String or list of strings to tokenize
+            **kwargs: Additional arguments passed to the tokenizer
+
+        Returns:
+            List of tokenizer Encodings
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return self.model.tokenize(texts, **kwargs)
 
     def embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
@@ -119,18 +119,18 @@ class LateInteractionMultimodalEmbedding(LateInteractionMultimodalEmbeddingBase)
             )
         return embedding_size
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: List of strings to tokenize
+            documents: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        return self.model.tokenize(texts, **kwargs)
+        return self.model.tokenize(documents, **kwargs)
 
     def embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
@@ -132,6 +132,9 @@ class LateInteractionMultimodalEmbedding(LateInteractionMultimodalEmbeddingBase)
         """
         return self.model.tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        return self.model.token_count(documents, **kwargs)
+
     def embed_text(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding.py
@@ -119,19 +119,17 @@ class LateInteractionMultimodalEmbedding(LateInteractionMultimodalEmbeddingBase)
             )
         return embedding_size
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: String or list of strings to tokenize
+            texts: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if isinstance(texts, str):
-            texts = [texts]
         return self.model.tokenize(texts, **kwargs)
 
     def embed_text(

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -22,7 +22,7 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed_text(

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -25,9 +25,6 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        raise NotImplementedError("Subclasses must implement this method.")
-
     def embed_text(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -25,6 +25,9 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def embed_text(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -22,7 +22,7 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed_text(

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -1,5 +1,6 @@
 from typing import Iterable, Optional, Union, Any
 
+from tokenizers import Encoding
 
 from fastembed.common import ImageInput
 from fastembed.common.model_description import DenseModelDescription
@@ -20,6 +21,9 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        raise NotImplementedError()
 
     def embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
+++ b/fastembed/late_interaction_multimodal/late_interaction_multimodal_embedding_base.py
@@ -23,7 +23,7 @@ class LateInteractionMultimodalEmbeddingBase(ModelManagement[DenseModelDescripti
         self._embedding_size: Optional[int] = None
 
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        raise NotImplementedError()
+        raise NotImplementedError("Subclasses must implement this method.")
 
     def embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
+++ b/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
@@ -80,8 +80,8 @@ class OnnxMultimodalModel(OnnxModel[T]):
     def load_onnx_model(self) -> None:
         raise NotImplementedError("Subclasses must implement this method")
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(documents)  # type: ignore[union-attr]
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+        return self.tokenizer.encode_batch(texts)
 
     def onnx_embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
+++ b/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
@@ -81,7 +81,9 @@ class OnnxMultimodalModel(OnnxModel[T]):
         raise NotImplementedError("Subclasses must implement this method")
 
     def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(texts)  # type: ignore[union-attr]
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer not initialized")
+        return self.tokenizer.encode_batch(texts, **kwargs)  # type: ignore[union-attr]
 
     def onnx_embed_text(
         self,

--- a/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
+++ b/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
@@ -80,17 +80,17 @@ class OnnxMultimodalModel(OnnxModel[T]):
     def load_onnx_model(self) -> None:
         raise NotImplementedError("Subclasses must implement this method")
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def _tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         if self.tokenizer is None:
             raise RuntimeError("Tokenizer not initialized")
-        return self.tokenizer.encode_batch(texts, **kwargs)  # type: ignore[union-attr]
+        return self.tokenizer.encode_batch(documents, **kwargs)  # type: ignore[union-attr]
 
     def onnx_embed_text(
         self,
         documents: list[str],
         **kwargs: Any,
     ) -> OnnxOutputContext:
-        encoded = self.tokenize(documents, **kwargs)
+        encoded = self._tokenize(documents, **kwargs)
         input_ids = np.array([e.ids for e in encoded])
         attention_mask = np.array([e.attention_mask for e in encoded])  # type: ignore[union-attr]
         input_names = {node.name for node in self.model.get_inputs()}  # type: ignore[union-attr]

--- a/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
+++ b/fastembed/late_interaction_multimodal/onnx_multimodal_model.py
@@ -81,7 +81,7 @@ class OnnxMultimodalModel(OnnxModel[T]):
         raise NotImplementedError("Subclasses must implement this method")
 
     def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(texts)
+        return self.tokenizer.encode_batch(texts)  # type: ignore[union-attr]
 
     def onnx_embed_text(
         self,

--- a/fastembed/rerank/cross_encoder/onnx_text_model.py
+++ b/fastembed/rerank/cross_encoder/onnx_text_model.py
@@ -45,8 +45,10 @@ class OnnxCrossEncoderModel(OnnxModel[float]):
         self.tokenizer, _ = load_tokenizer(model_dir=model_dir)
         assert self.tokenizer is not None
 
-    def tokenize(self, pairs: list[tuple[str, str]], **_: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(pairs)  # type: ignore[union-attr]
+    def tokenize(self, pairs: list[tuple[str, str]], **kwargs: Any) -> list[Encoding]:
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer not initialized")
+        return self.tokenizer.encode_batch(pairs, **kwargs)  # type: ignore[union-attr]
 
     def _build_onnx_input(self, tokenized_input: list[Encoding]) -> dict[str, NumpyArray]:
         input_names: set[str] = {node.name for node in self.model.get_inputs()}  # type: ignore[union-attr]

--- a/fastembed/rerank/cross_encoder/onnx_text_model.py
+++ b/fastembed/rerank/cross_encoder/onnx_text_model.py
@@ -46,8 +46,6 @@ class OnnxCrossEncoderModel(OnnxModel[float]):
         assert self.tokenizer is not None
 
     def tokenize(self, pairs: list[tuple[str, str]], **kwargs: Any) -> list[Encoding]:
-        if self.tokenizer is None:
-            raise RuntimeError("Tokenizer not initialized")
         return self.tokenizer.encode_batch(pairs, **kwargs)  # type: ignore[union-attr]
 
     def _build_onnx_input(self, tokenized_input: list[Encoding]) -> dict[str, NumpyArray]:

--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -137,25 +137,25 @@ class Bm25(SparseTextEmbeddingBase):
 
         self.tokenizer = SimpleTokenizer
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """Tokenize texts using SimpleTokenizer.
 
         Returns a list of simple Encoding-like objects with token strings.
         Note: BM25 uses a simple word tokenizer, not a learned tokenizer.
         """
         result = []
-        for text in texts:
-            tokens = self.tokenizer.tokenize(text)
 
-            # Create a simple object that mimics Encoding interface
-            class SimpleEncoding:
-                def __init__(self, tokens: list[str]):
-                    self.tokens = tokens
-                    self.ids = tokens  # For BM25, tokens are the IDs
-                    self.attention_mask = [1] * len(tokens)
+        class SimpleEncoding:
+            def __init__(self, tokens: list[str]):
+                self.tokens = tokens
+                self.ids = tokens  # For BM25, tokens are the IDs
+                self.attention_mask = [1] * len(tokens)
 
-            result.append(SimpleEncoding(tokens))  # type: ignore[arg-type]
-        return result  # type: ignore[return-value]
+        for document in documents:
+            tokens = self.tokenizer.tokenize(document)
+            result.append(SimpleEncoding(tokens))
+
+        return result
 
     @classmethod
     def _list_supported_models(cls) -> list[SparseModelDescription]:

--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -7,6 +7,7 @@ from typing import Any, Iterable, Optional, Type, Union
 import mmh3
 import numpy as np
 from py_rust_stemmers import SnowballStemmer
+from tokenizers import Encoding
 from fastembed.common.utils import (
     define_cache_dir,
     iter_batch,
@@ -135,6 +136,26 @@ class Bm25(SparseTextEmbeddingBase):
             self.stemmer = SnowballStemmer(language)
 
         self.tokenizer = SimpleTokenizer
+
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+        """Tokenize texts using SimpleTokenizer.
+
+        Returns a list of simple Encoding-like objects with token strings.
+        Note: BM25 uses a simple word tokenizer, not a learned tokenizer.
+        """
+        result = []
+        for text in texts:
+            tokens = self.tokenizer.tokenize(text)
+
+            # Create a simple object that mimics Encoding interface
+            class SimpleEncoding:
+                def __init__(self, tokens: list[str]):
+                    self.tokens = tokens
+                    self.ids = tokens  # For BM25, tokens are the IDs
+                    self.attention_mask = [1] * len(tokens)
+
+            result.append(SimpleEncoding(tokens))  # type: ignore[arg-type]
+        return result  # type: ignore[return-value]
 
     @classmethod
     def _list_supported_models(cls) -> list[SparseModelDescription]:

--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -7,7 +7,6 @@ from typing import Any, Iterable, Optional, Type, Union
 import mmh3
 import numpy as np
 from py_rust_stemmers import SnowballStemmer
-from tokenizers import Encoding
 from fastembed.common.utils import (
     define_cache_dir,
     iter_batch,
@@ -137,25 +136,8 @@ class Bm25(SparseTextEmbeddingBase):
 
         self.tokenizer = SimpleTokenizer
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        """Tokenize texts using SimpleTokenizer.
-
-        Returns a list of simple Encoding-like objects with token strings.
-        Note: BM25 uses a simple word tokenizer, not a learned tokenizer.
-        """
-        result = []
-
-        class SimpleEncoding:
-            def __init__(self, tokens: list[str]):
-                self.tokens = tokens
-                self.ids = tokens  # For BM25, tokens are the IDs
-                self.attention_mask = [1] * len(tokens)
-
-        for document in documents:
-            tokens = self.tokenizer.tokenize(document)
-            result.append(SimpleEncoding(tokens))
-
-        return result
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     @classmethod
     def _list_supported_models(cls) -> list[SparseModelDescription]:

--- a/fastembed/sparse/bm42.py
+++ b/fastembed/sparse/bm42.py
@@ -44,7 +44,7 @@ def get_language_by_model_name(model_name: str) -> str:
     return MODEL_TO_LANGUAGE[model_name.lower()]
 
 
-class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
+class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ignore[misc]
     """
     Bm42 is an extension of BM25, which tries to better evaluate importance of tokens in the documents,
     by extracting attention weights from the transformer model.

--- a/fastembed/sparse/bm42.py
+++ b/fastembed/sparse/bm42.py
@@ -16,6 +16,7 @@ from fastembed.sparse.sparse_embedding_base import (
 )
 from fastembed.text.onnx_text_model import OnnxTextModel, TextEmbeddingWorker
 from fastembed.common.model_description import SparseModelDescription, ModelSource
+from tokenizers import Encoding
 
 supported_bm42_models: list[SparseModelDescription] = [
     SparseModelDescription(
@@ -137,6 +138,9 @@ class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ig
 
         if not self.lazy_load:
             self.load_onnx_model()
+
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/bm42.py
+++ b/fastembed/sparse/bm42.py
@@ -16,7 +16,6 @@ from fastembed.sparse.sparse_embedding_base import (
 )
 from fastembed.text.onnx_text_model import OnnxTextModel, TextEmbeddingWorker
 from fastembed.common.model_description import SparseModelDescription, ModelSource
-from tokenizers import Encoding
 
 supported_bm42_models: list[SparseModelDescription] = [
     SparseModelDescription(
@@ -139,8 +138,8 @@ class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
         if not self.lazy_load:
             self.load_onnx_model()
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        return self._tokenize(documents, **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/bm42.py
+++ b/fastembed/sparse/bm42.py
@@ -45,7 +45,7 @@ def get_language_by_model_name(model_name: str) -> str:
     return MODEL_TO_LANGUAGE[model_name.lower()]
 
 
-class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ignore[misc]
+class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
     """
     Bm42 is an extension of BM25, which tries to better evaluate importance of tokens in the documents,
     by extracting attention weights from the transformer model.
@@ -139,8 +139,8 @@ class Bm42(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ig
         if not self.lazy_load:
             self.load_onnx_model()
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self._tokenize(documents, **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/minicoil.py
+++ b/fastembed/sparse/minicoil.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Sequence, Iterable, Union, Type
 import numpy as np
 from numpy.typing import NDArray
 from py_rust_stemmers import SnowballStemmer
-from tokenizers import Tokenizer, Encoding
+from tokenizers import Tokenizer
 
 from fastembed.common.model_description import SparseModelDescription, ModelSource
 from fastembed.common.onnx_model import OnnxOutputContext
@@ -145,8 +145,8 @@ class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
         if not self.lazy_load:
             self.load_onnx_model()
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        return self._tokenize(documents, **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/minicoil.py
+++ b/fastembed/sparse/minicoil.py
@@ -58,7 +58,7 @@ def get_language_by_model_name(model_name: str) -> str:
     return MODEL_TO_LANGUAGE[model_name.lower()]
 
 
-class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
+class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ignore[misc]
     """
         MiniCOIL is a sparse embedding model, that resolves semantic meaning of the words,
         while keeping exact keyword match behavior.

--- a/fastembed/sparse/minicoil.py
+++ b/fastembed/sparse/minicoil.py
@@ -5,7 +5,7 @@ from typing import Any, Optional, Sequence, Iterable, Union, Type
 import numpy as np
 from numpy.typing import NDArray
 from py_rust_stemmers import SnowballStemmer
-from tokenizers import Tokenizer
+from tokenizers import Tokenizer, Encoding
 
 from fastembed.common.model_description import SparseModelDescription, ModelSource
 from fastembed.common.onnx_model import OnnxOutputContext
@@ -144,6 +144,9 @@ class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type
 
         if not self.lazy_load:
             self.load_onnx_model()
+
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/minicoil.py
+++ b/fastembed/sparse/minicoil.py
@@ -58,7 +58,7 @@ def get_language_by_model_name(model_name: str) -> str:
     return MODEL_TO_LANGUAGE[model_name.lower()]
 
 
-class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type: ignore[misc]
+class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
     """
         MiniCOIL is a sparse embedding model, that resolves semantic meaning of the words,
         while keeping exact keyword match behavior.
@@ -145,8 +145,8 @@ class MiniCOIL(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):  # type
         if not self.lazy_load:
             self.load_onnx_model()
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self._tokenize(documents, **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -47,9 +47,6 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
         raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        raise NotImplementedError("Token count for sparse embeddings is not implemented.")
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -3,7 +3,6 @@ from typing import Iterable, Optional, Union, Any
 
 import numpy as np
 from numpy.typing import NDArray
-from tokenizers import Encoding
 
 from fastembed.common.model_description import SparseModelDescription
 from fastembed.common.types import NumpyArray
@@ -45,8 +44,8 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        raise NotImplementedError()
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     def embed(
         self,

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -47,6 +47,9 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
         raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        raise NotImplementedError("Token count for sparse embeddings is not implemented.")
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -45,7 +45,7 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -3,6 +3,7 @@ from typing import Iterable, Optional, Union, Any
 
 import numpy as np
 from numpy.typing import NDArray
+from tokenizers import Encoding
 
 from fastembed.common.model_description import SparseModelDescription
 from fastembed.common.types import NumpyArray
@@ -43,6 +44,9 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
         self.cache_dir = cache_dir
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        raise NotImplementedError()
 
     def embed(
         self,

--- a/fastembed/sparse/sparse_embedding_base.py
+++ b/fastembed/sparse/sparse_embedding_base.py
@@ -45,7 +45,7 @@ class SparseTextEmbeddingBase(ModelManagement[SparseModelDescription]):
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -1,9 +1,10 @@
-from typing import Any, Iterable, Optional, Sequence, Type, Union
+import warnings
 from dataclasses import asdict
+from typing import Any, Iterable, Optional, Sequence, Type, Union
 
-from tokenizers import Encoding
 
 from fastembed.common import OnnxProvider
+from fastembed.common.model_description import SparseModelDescription
 from fastembed.sparse.bm25 import Bm25
 from fastembed.sparse.bm42 import Bm42
 from fastembed.sparse.minicoil import MiniCOIL
@@ -12,8 +13,6 @@ from fastembed.sparse.sparse_embedding_base import (
     SparseTextEmbeddingBase,
 )
 from fastembed.sparse.splade_pp import SpladePP
-import warnings
-from fastembed.common.model_description import SparseModelDescription
 
 
 class SparseTextEmbedding(SparseTextEmbeddingBase):
@@ -93,18 +92,8 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
             "Please check the supported models using `SparseTextEmbedding.list_supported_models()`"
         )
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        """
-        Tokenize input texts using the model's tokenizer.
-
-        Args:
-            documents: List of strings to tokenize
-            **kwargs: Additional arguments passed to the tokenizer
-
-        Returns:
-            List of tokenizer Encodings
-        """
-        return self.model.tokenize(documents, **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     def embed(
         self,

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -95,9 +95,6 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
     def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
         raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        raise NotImplementedError("Token count for sparse embeddings is not implemented.")
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -93,18 +93,18 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
             "Please check the supported models using `SparseTextEmbedding.list_supported_models()`"
         )
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: List of strings to tokenize
+            documents: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        return self.model.tokenize(texts, **kwargs)
+        return self.model.tokenize(documents, **kwargs)
 
     def embed(
         self,

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 from dataclasses import asdict
 
+from tokenizers import Encoding
+
 from fastembed.common import OnnxProvider
 from fastembed.sparse.bm25 import Bm25
 from fastembed.sparse.bm42 import Bm42
@@ -90,6 +92,21 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
             f"Model {model_name} is not supported in SparseTextEmbedding."
             "Please check the supported models using `SparseTextEmbedding.list_supported_models()`"
         )
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        """
+        Tokenize input texts using the model's tokenizer.
+
+        Args:
+            texts: String or list of strings to tokenize
+            **kwargs: Additional arguments passed to the tokenizer
+
+        Returns:
+            List of tokenizer Encodings
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return self.model.tokenize(texts, **kwargs)
 
     def embed(
         self,

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -95,6 +95,9 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
     def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
         raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        raise NotImplementedError("Token count for sparse embeddings is not implemented.")
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/sparse/sparse_text_embedding.py
+++ b/fastembed/sparse/sparse_text_embedding.py
@@ -93,19 +93,17 @@ class SparseTextEmbedding(SparseTextEmbeddingBase):
             "Please check the supported models using `SparseTextEmbedding.list_supported_models()`"
         )
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: String or list of strings to tokenize
+            texts: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if isinstance(texts, str):
-            texts = [texts]
         return self.model.tokenize(texts, **kwargs)
 
     def embed(

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -137,20 +137,18 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
             device_id=self.device_id,
         )
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: List of strings to tokenize
+            documents: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if self.tokenizer is None:
-            raise RuntimeError("Tokenizer not initialized")
-        return self.tokenizer.encode_batch(texts, **kwargs)
+        return self._tokenize(documents, **kwargs)
 
     def embed(
         self,

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -1,6 +1,8 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 
 import numpy as np
+from tokenizers import Encoding
+
 from fastembed.common import OnnxProvider
 from fastembed.common.onnx_model import OnnxOutputContext
 from fastembed.common.utils import define_cache_dir
@@ -134,6 +136,21 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
             cuda=self.cuda,
             device_id=self.device_id,
         )
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        """
+        Tokenize input texts using the model's tokenizer.
+
+        Args:
+            texts: String or list of strings to tokenize
+            **kwargs: Additional arguments passed to the tokenizer
+
+        Returns:
+            List of tokenizer Encodings
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return self.tokenizer.encode_batch(texts)
 
     def embed(
         self,

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -137,7 +137,7 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
             device_id=self.device_id,
         )
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         """
         Tokenize input texts using the model's tokenizer.
 
@@ -150,6 +150,9 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
         """
         if isinstance(texts, str):
             texts = [texts]
+        if not isinstance(texts, list):
+            texts = list(texts)
+        assert self.tokenizer is not None
         return self.tokenizer.encode_batch(texts)
 
     def embed(

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -1,7 +1,6 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 
 import numpy as np
-from tokenizers import Encoding
 
 from fastembed.common import OnnxProvider
 from fastembed.common.onnx_model import OnnxOutputContext
@@ -137,18 +136,8 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
             device_id=self.device_id,
         )
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        """
-        Tokenize input texts using the model's tokenizer.
-
-        Args:
-            documents: List of strings to tokenize
-            **kwargs: Additional arguments passed to the tokenizer
-
-        Returns:
-            List of tokenizer Encodings
-        """
-        return self._tokenize(documents, **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> dict[str, Any]:
+        raise NotImplementedError("Tokenize method for sparse embeddings is not implemented yet.")
 
     def embed(
         self,

--- a/fastembed/sparse/splade_pp.py
+++ b/fastembed/sparse/splade_pp.py
@@ -137,23 +137,20 @@ class SpladePP(SparseTextEmbeddingBase, OnnxTextModel[SparseEmbedding]):
             device_id=self.device_id,
         )
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: String or list of strings to tokenize
+            texts: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if isinstance(texts, str):
-            texts = [texts]
-        if not isinstance(texts, list):
-            texts = list(texts)
-        assert self.tokenizer is not None
-        return self.tokenizer.encode_batch(texts)
+        if self.tokenizer is None:
+            raise RuntimeError("Tokenizer not initialized")
+        return self.tokenizer.encode_batch(texts, **kwargs)
 
     def embed(
         self,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -324,6 +324,16 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        encoded = self._tokenize(documents, **kwargs)
+        counts: list[int] = []
+        for e in encoded:
+            try:
+                counts.append(int(sum(e.attention_mask)))  # type: ignore[arg-type]
+            except Exception:
+                counts.append(len(e.ids))
+        return counts
+
     def load_onnx_model(self) -> None:
         self._load_onnx_model(
             model_dir=self._model_dir,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -324,16 +324,6 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         return self._tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        encoded = self._tokenize(documents, **kwargs)
-        counts: list[int] = []
-        for e in encoded:
-            try:
-                counts.append(int(sum(e.attention_mask)))  # type: ignore[arg-type]
-            except Exception:
-                counts.append(len(e.ids))
-        return counts
-
     def load_onnx_model(self) -> None:
         self._load_onnx_model(
             model_dir=self._model_dir,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -183,7 +183,7 @@ supported_onnx_models: list[DenseModelDescription] = [
 ]
 
 
-class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
+class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):  # type: ignore[misc]
     """Implementation of the Flag Embedding model."""
 
     @classmethod

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -1,5 +1,7 @@
 from typing import Any, Iterable, Optional, Sequence, Type, Union
 
+from tokenizers import Encoding
+
 from fastembed.common.types import NumpyArray, OnnxProvider
 from fastembed.common.onnx_model import OnnxOutputContext
 from fastembed.common.utils import define_cache_dir, normalize
@@ -318,6 +320,20 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):  # type: 
         else:
             raise ValueError(f"Unsupported embedding shape: {embeddings.shape}")
         return normalize(processed_embeddings)
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+        """Tokenize the input texts.
+
+        Args:
+            texts: A single string or an iterable of strings to tokenize.
+            **kwargs: Additional keyword arguments.
+
+        Returns:
+            list[Encoding]: List of tokenized encodings.
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -321,19 +321,17 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):  # type: 
             raise ValueError(f"Unsupported embedding shape: {embeddings.shape}")
         return normalize(processed_embeddings)
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:  # type: ignore[override]
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         """Tokenize the input texts.
 
         Args:
-            texts: A single string or an iterable of strings to tokenize.
+            texts: A list of strings to tokenize.
             **kwargs: Additional keyword arguments.
 
         Returns:
             list[Encoding]: List of tokenized encodings.
         """
-        if isinstance(texts, str):
-            texts = [texts]
-        return OnnxTextModel.tokenize(self, list(texts), **kwargs)
+        return OnnxTextModel.tokenize(self, texts, **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -185,7 +185,7 @@ supported_onnx_models: list[DenseModelDescription] = [
 ]
 
 
-class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):  # type: ignore[misc]
+class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):
     """Implementation of the Flag Embedding model."""
 
     @classmethod
@@ -321,17 +321,8 @@ class OnnxTextEmbedding(TextEmbeddingBase, OnnxTextModel[NumpyArray]):  # type: 
             raise ValueError(f"Unsupported embedding shape: {embeddings.shape}")
         return normalize(processed_embeddings)
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        """Tokenize the input texts.
-
-        Args:
-            texts: A list of strings to tokenize.
-            **kwargs: Additional keyword arguments.
-
-        Returns:
-            list[Encoding]: List of tokenized encodings.
-        """
-        return OnnxTextModel.tokenize(self, texts, **kwargs)
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self._tokenize(documents, **kwargs)
 
     def load_onnx_model(self) -> None:
         self._load_onnx_model(

--- a/fastembed/text/onnx_text_model.py
+++ b/fastembed/text/onnx_text_model.py
@@ -68,15 +68,15 @@ class OnnxTextModel(OnnxModel[T]):
     def load_onnx_model(self) -> None:
         raise NotImplementedError("Subclasses must implement this method")
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(texts)  # type: ignore[union-attr]
+    def _tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
+        return self.tokenizer.encode_batch(documents)  # type:ignore[union-attr]
 
     def onnx_embed(
         self,
         documents: list[str],
         **kwargs: Any,
     ) -> OnnxOutputContext:
-        encoded = self.tokenize(documents, **kwargs)
+        encoded = self._tokenize(documents, **kwargs)
         input_ids = np.array([e.ids for e in encoded])
         attention_mask = np.array([e.attention_mask for e in encoded])
         input_names = {node.name for node in self.model.get_inputs()}  # type: ignore[union-attr]

--- a/fastembed/text/onnx_text_model.py
+++ b/fastembed/text/onnx_text_model.py
@@ -68,8 +68,8 @@ class OnnxTextModel(OnnxModel[T]):
     def load_onnx_model(self) -> None:
         raise NotImplementedError("Subclasses must implement this method")
 
-    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        return self.tokenizer.encode_batch(documents)  # type: ignore[union-attr]
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+        return self.tokenizer.encode_batch(texts)  # type: ignore[union-attr]
 
     def onnx_embed(
         self,

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -176,9 +176,6 @@ class TextEmbedding(TextEmbeddingBase):
         """
         return self.model.tokenize(documents, **kwargs)
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        return self.model.token_count(documents, **kwargs)
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -1,5 +1,6 @@
 import warnings
 from typing import Any, Iterable, Optional, Sequence, Type, Union
+from tokenizers import Encoding
 from dataclasses import asdict
 
 from fastembed.common.types import NumpyArray, OnnxProvider
@@ -161,6 +162,21 @@ class TextEmbedding(TextEmbeddingBase):
                 f"Available model names: {model_names}"
             )
         return embedding_size
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        """
+        Tokenize input texts using the model's tokenizer.
+
+        Args:
+            texts: String or list of strings to tokenize
+            **kwargs: Additional arguments passed to the tokenizer
+
+        Returns:
+            List of tokenizer Encodings
+        """
+        if isinstance(texts, str):
+            texts = [texts]
+        return self.model.tokenize(texts, **kwargs)
 
     def embed(
         self,

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -163,19 +163,17 @@ class TextEmbedding(TextEmbeddingBase):
             )
         return embedding_size
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: String or list of strings to tokenize
+            texts: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        if isinstance(texts, str):
-            texts = [texts]
         return self.model.tokenize(texts, **kwargs)
 
     def embed(

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -176,6 +176,9 @@ class TextEmbedding(TextEmbeddingBase):
         """
         return self.model.tokenize(documents, **kwargs)
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        return self.model.token_count(documents, **kwargs)
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -163,18 +163,18 @@ class TextEmbedding(TextEmbeddingBase):
             )
         return embedding_size
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         """
         Tokenize input texts using the model's tokenizer.
 
         Args:
-            texts: List of strings to tokenize
+            documents: List of strings to tokenize
             **kwargs: Additional arguments passed to the tokenizer
 
         Returns:
             List of tokenizer Encodings
         """
-        return self.model.tokenize(texts, **kwargs)
+        return self.model.tokenize(documents, **kwargs)
 
     def embed(
         self,

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -23,6 +23,9 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
+    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
+        raise NotImplementedError("Subclasses must implement this method.")
+
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -21,7 +21,7 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._embedding_size: Optional[int] = None
 
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
-        raise NotImplementedError()
+        raise NotImplementedError("Subclasses must implement this method.")
 
     def embed(
         self,

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -20,7 +20,7 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -23,9 +23,6 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
     def tokenize(self, documents: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError("Subclasses must implement this method.")
 
-    def token_count(self, documents: list[str], **kwargs: Any) -> list[int]:
-        raise NotImplementedError("Subclasses must implement this method.")
-
     def embed(
         self,
         documents: Union[str, Iterable[str]],

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -20,7 +20,7 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
 
-    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+    def tokenize(self, texts: list[str], **kwargs: Any) -> list[Encoding]:
         raise NotImplementedError()
 
     def embed(

--- a/fastembed/text/text_embedding_base.py
+++ b/fastembed/text/text_embedding_base.py
@@ -1,4 +1,5 @@
 from typing import Iterable, Optional, Union, Any
+from tokenizers import Encoding
 
 from fastembed.common.model_description import DenseModelDescription
 from fastembed.common.types import NumpyArray
@@ -18,6 +19,9 @@ class TextEmbeddingBase(ModelManagement[DenseModelDescription]):
         self.threads = threads
         self._local_files_only = kwargs.pop("local_files_only", False)
         self._embedding_size: Optional[int] = None
+
+    def tokenize(self, texts: Union[str, Iterable[str]], **kwargs: Any) -> list[Encoding]:
+        raise NotImplementedError()
 
     def embed(
         self,

--- a/tests/test_late_interaction_embeddings.py
+++ b/tests/test_late_interaction_embeddings.py
@@ -310,22 +310,26 @@ def test_embedding_size():
         delete_model_cache(model.model._model_dir)
 
 
-@pytest.mark.parametrize("model_name", ["colbert-ir/colbertv2.0"])
+@pytest.mark.parametrize("model_name", ["answerdotai/answerai-colbert-small-v1"])
 def test_tokenize(model_name: str) -> None:
     is_ci = os.getenv("CI")
     model = LateInteractionTextEmbedding(model_name=model_name)
 
     texts = ["hello world", "flag embedding"]
-    encodings = model.tokenize(texts, is_doc=True)
-    assert len(encodings) == 2
-    for encoding in encodings:
+    enc_doc = model.tokenize(texts, is_doc=True)
+    assert len(enc_doc) == 2
+    for encoding in enc_doc:
         assert encoding.ids is not None
         assert len(encoding.ids) > 0
 
-    encodings = model.tokenize(["hello world"], is_doc=False)
-    assert len(encodings) == 1
-    assert encodings[0].ids is not None
-    assert len(encodings[0].ids) > 0
+    enc_query = model.tokenize(["hello world"], is_doc=False)
+    assert len(enc_query) == 1
+    assert enc_query[0].ids is not None
+    assert len(enc_query[0].ids) > 0
+
+    doc_ids = list(enc_doc[0].ids)
+    query_ids = list(enc_query[0].ids)
+    assert doc_ids != query_ids
 
     if is_ci:
         delete_model_cache(model.model._model_dir)

--- a/tests/test_late_interaction_embeddings.py
+++ b/tests/test_late_interaction_embeddings.py
@@ -308,3 +308,24 @@ def test_embedding_size():
     assert model.embedding_size == 96
     if is_ci:
         delete_model_cache(model.model._model_dir)
+
+
+@pytest.mark.parametrize("model_name", ["colbert-ir/colbertv2.0"])
+def test_tokenize(model_name: str) -> None:
+    is_ci = os.getenv("CI")
+    model = LateInteractionTextEmbedding(model_name=model_name)
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts, is_doc=True)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    encodings = model.tokenize(["hello world"], is_doc=False)
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    if is_ci:
+        delete_model_cache(model.model._model_dir)

--- a/tests/test_late_interaction_multimodal.py
+++ b/tests/test_late_interaction_multimodal.py
@@ -101,3 +101,23 @@ def test_embedding_size():
     model_name = "Qdrant/ColPali-v1.3-fp16"
     model = LateInteractionMultimodalEmbedding(model_name=model_name, lazy_load=True)
     assert model.embedding_size == 128
+
+
+@pytest.mark.parametrize("model_name", ["Qdrant/colpali-v1.3-fp16"])
+def test_tokenize(model_name: str) -> None:
+    if os.getenv("CI"):
+        pytest.skip("Colpali is too large to test in CI")
+
+    model = LateInteractionMultimodalEmbedding(model_name=model_name)
+
+    encodings = model.tokenize(["hello world"])
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -283,7 +283,7 @@ def test_tokenize(model_name: str) -> None:
     is_ci = os.getenv("CI")
     model = SparseTextEmbedding(model_name=model_name)
 
-    encodings = model.tokenize("hello world")
+    encodings = model.tokenize(["hello world"])
     assert len(encodings) == 1
     assert encodings[0].ids is not None
     assert len(encodings[0].ids) > 0

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -5,8 +5,6 @@ import pytest
 import numpy as np
 
 from fastembed.sparse.bm25 import Bm25
-from fastembed.sparse.bm42 import Bm42
-from fastembed.sparse.minicoil import MiniCOIL
 from fastembed.sparse.sparse_text_embedding import SparseTextEmbedding
 from tests.utils import delete_model_cache, should_test_model
 
@@ -280,9 +278,18 @@ def test_lazy_load(model_name: str) -> None:
         delete_model_cache(model.model._model_dir)
 
 
-@pytest.mark.parametrize("model_name", ["prithivida/Splade_PP_en_v1"])
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "prithivida/Splade_PP_en_v1",
+        "Qdrant/bm25",
+        "Qdrant/bm42-all-minilm-l6-v2-attentions",
+        "Qdrant/minicoil-v1",
+    ],
+)
 def test_tokenize(model_name: str) -> None:
     is_ci = os.getenv("CI")
+
     model = SparseTextEmbedding(model_name=model_name)
 
     encodings = model.tokenize(["hello world"])
@@ -299,63 +306,3 @@ def test_tokenize(model_name: str) -> None:
 
     if is_ci:
         delete_model_cache(model.model._model_dir)
-
-
-def test_tokenize_bm25() -> None:
-    is_ci = os.getenv("CI")
-    model = Bm25("Qdrant/bm25", language="english")
-
-    encodings = model.tokenize(["hello world"])
-    assert len(encodings) == 1
-    assert encodings[0].ids is not None
-    assert len(encodings[0].ids) > 0
-
-    texts = ["hello world", "flag embedding"]
-    encodings = model.tokenize(texts)
-    assert len(encodings) == 2
-    for encoding in encodings:
-        assert encoding.ids is not None
-        assert len(encoding.ids) > 0
-
-    if is_ci:
-        delete_model_cache(model._model_dir)
-
-
-def test_tokenize_bm42() -> None:
-    is_ci = os.getenv("CI")
-    model = Bm42("Qdrant/bm42-all-minilm-l6-v2-attentions")
-
-    encodings = model.tokenize(["hello world"])
-    assert len(encodings) == 1
-    assert encodings[0].ids is not None
-    assert len(encodings[0].ids) > 0
-
-    texts = ["hello world", "flag embedding"]
-    encodings = model.tokenize(texts)
-    assert len(encodings) == 2
-    for encoding in encodings:
-        assert encoding.ids is not None
-        assert len(encoding.ids) > 0
-
-    if is_ci:
-        delete_model_cache(model._model_dir)
-
-
-def test_tokenize_minicoil() -> None:
-    is_ci = os.getenv("CI")
-    model = MiniCOIL("Qdrant/minicoil-v1")
-
-    encodings = model.tokenize(["hello world"])
-    assert len(encodings) == 1
-    assert encodings[0].ids is not None
-    assert len(encodings[0].ids) > 0
-
-    texts = ["hello world", "flag embedding"]
-    encodings = model.tokenize(texts)
-    assert len(encodings) == 2
-    for encoding in encodings:
-        assert encoding.ids is not None
-        assert len(encoding.ids) > 0
-
-    if is_ci:
-        delete_model_cache(model._model_dir)

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -1,8 +1,8 @@
 import os
 from contextlib import contextmanager
 
-import pytest
 import numpy as np
+import pytest
 
 from fastembed.sparse.bm25 import Bm25
 from fastembed.sparse.sparse_text_embedding import SparseTextEmbedding
@@ -273,36 +273,6 @@ def test_lazy_load(model_name: str) -> None:
 
     model = SparseTextEmbedding(model_name=model_name, lazy_load=True)
     list(model.passage_embed(docs))
-
-    if is_ci:
-        delete_model_cache(model.model._model_dir)
-
-
-@pytest.mark.parametrize(
-    "model_name",
-    [
-        "prithivida/Splade_PP_en_v1",
-        "Qdrant/bm25",
-        "Qdrant/bm42-all-minilm-l6-v2-attentions",
-        "Qdrant/minicoil-v1",
-    ],
-)
-def test_tokenize(model_name: str) -> None:
-    is_ci = os.getenv("CI")
-
-    model = SparseTextEmbedding(model_name=model_name)
-
-    encodings = model.tokenize(["hello world"])
-    assert len(encodings) == 1
-    assert encodings[0].ids is not None
-    assert len(encodings[0].ids) > 0
-
-    texts = ["hello world", "flag embedding"]
-    encodings = model.tokenize(texts)
-    assert len(encodings) == 2
-    for encoding in encodings:
-        assert encoding.ids is not None
-        assert len(encoding.ids) > 0
 
     if is_ci:
         delete_model_cache(model.model._model_dir)

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -276,3 +276,24 @@ def test_lazy_load(model_name: str) -> None:
 
     if is_ci:
         delete_model_cache(model.model._model_dir)
+
+
+@pytest.mark.parametrize("model_name", ["prithivida/Splade_PP_en_v1"])
+def test_tokenize(model_name: str) -> None:
+    is_ci = os.getenv("CI")
+    model = SparseTextEmbedding(model_name=model_name)
+
+    encodings = model.tokenize("hello world")
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    if is_ci:
+        delete_model_cache(model.model._model_dir)

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -5,6 +5,8 @@ import pytest
 import numpy as np
 
 from fastembed.sparse.bm25 import Bm25
+from fastembed.sparse.bm42 import Bm42
+from fastembed.sparse.minicoil import MiniCOIL
 from fastembed.sparse.sparse_text_embedding import SparseTextEmbedding
 from tests.utils import delete_model_cache, should_test_model
 
@@ -297,3 +299,63 @@ def test_tokenize(model_name: str) -> None:
 
     if is_ci:
         delete_model_cache(model.model._model_dir)
+
+
+def test_tokenize_bm25() -> None:
+    is_ci = os.getenv("CI")
+    model = Bm25("Qdrant/bm25", language="english")
+
+    encodings = model.tokenize(["hello world"])
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    if is_ci:
+        delete_model_cache(model._model_dir)
+
+
+def test_tokenize_bm42() -> None:
+    is_ci = os.getenv("CI")
+    model = Bm42("Qdrant/bm42-all-minilm-l6-v2-attentions")
+
+    encodings = model.tokenize(["hello world"])
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    if is_ci:
+        delete_model_cache(model._model_dir)
+
+
+def test_tokenize_minicoil() -> None:
+    is_ci = os.getenv("CI")
+    model = MiniCOIL("Qdrant/minicoil-v1")
+
+    encodings = model.tokenize(["hello world"])
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    if is_ci:
+        delete_model_cache(model._model_dir)

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -193,3 +193,24 @@ def test_embedding_size() -> None:
 
     if is_ci:
         delete_model_cache(model.model._model_dir)
+
+
+@pytest.mark.parametrize("model_name", ["BAAI/bge-small-en-v1.5"])
+def test_tokenize(model_name: str) -> None:
+    is_ci = os.getenv("CI")
+    model = TextEmbedding(model_name=model_name)
+
+    encodings = model.tokenize("hello world")
+    assert len(encodings) == 1
+    assert encodings[0].ids is not None
+    assert len(encodings[0].ids) > 0
+
+    texts = ["hello world", "flag embedding"]
+    encodings = model.tokenize(texts)
+    assert len(encodings) == 2
+    for encoding in encodings:
+        assert encoding.ids is not None
+        assert len(encoding.ids) > 0
+
+    if is_ci:
+        delete_model_cache(model.model._model_dir)

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -195,10 +195,9 @@ def test_embedding_size() -> None:
         delete_model_cache(model.model._model_dir)
 
 
-@pytest.mark.parametrize("model_name", ["BAAI/bge-small-en-v1.5"])
-def test_tokenize(model_name: str) -> None:
+def test_tokenize() -> None:
     is_ci = os.getenv("CI")
-    model = TextEmbedding(model_name=model_name)
+    model = TextEmbedding()
 
     encodings = model.tokenize(["hello world"])
     assert len(encodings) == 1

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -200,7 +200,7 @@ def test_tokenize(model_name: str) -> None:
     is_ci = os.getenv("CI")
     model = TextEmbedding(model_name=model_name)
 
-    encodings = model.tokenize("hello world")
+    encodings = model.tokenize(["hello world"])
     assert len(encodings) == 1
     assert encodings[0].ids is not None
     assert len(encodings[0].ids) > 0


### PR DESCRIPTION
Expose `tokenize` method instead of using `embedding_model.model.tokenize`.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass the existing tests?
* [ ] Have you added tests for your feature?
* [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### New models submission:

* [x] Have you added an explanation of why it's important to include this model?
* [ ] Have you added tests for the new model? Were canonical values for tests computed via the original model?
* [ ] Have you added the code snippet for how canonical values were computed?
* [x] Have you successfully ran tests with your changes locally?
