### PR TITLE
Correct Qdrant/bge-base-en-v1.5-onnx-Q model name

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -34,7 +34,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         license="mit",
         size_in_GB=0.21,
         sources=ModelSource(
-            hf="qdrant/bge-base-en-v1.5-onnx-q",
+            hf="Qdrant/bge-base-en-v1.5-onnx-Q",
             url="https://storage.googleapis.com/qdrant-fastembed/fast-bge-base-en-v1.5.tar.gz",
             _deprecated_tar_struct=True,
         ),


### PR DESCRIPTION
Wrong name causes HTTP redirection, what may be wrongly handled by proxies.

### All Submissions:

* [X] Have you followed the guidelines in our Contributing document?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?