### PR TITLE
fix: respect HF_HUB_OFFLINE in download_model to avoid network calls

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -395,6 +395,10 @@ class ModelManagement(Generic[T]):
             Path: The path to the downloaded model directory.
         """
         local_files_only = kwargs.get("local_files_only", False)
+        hf_offline = os.environ.get("HF_HUB_OFFLINE", "").strip().upper()
+        if not local_files_only and hf_offline in {"1", "TRUE", "YES", "ON"}:
+            local_files_only = True
+            kwargs["local_files_only"] = True
         specific_model_path: str | None = kwargs.pop("specific_model_path", None)
         if specific_model_path:
             return Path(specific_model_path)


### PR DESCRIPTION
Fixes #615
Related: #565

## Summary

When `HF_HUB_OFFLINE` is set to a truthy value (`1`, `true`, `yes`, `on`), `download_model()` should not attempt any network calls. Currently, even though there is a `local_files_only=True` first pass, if it fails (e.g. missing metadata file), the retry loop still calls `download_files_from_huggingface()` without `local_files_only`, which triggers `model_info()` — a network API call that immediately raises `EnvironmentError` in offline mode. This causes an unnecessary fallback to GCS, downloading ~83MB from `storage.googleapis.com` on every startup.

In air-gapped / restricted environments where both HuggingFace and Google Cloud Storage are unreachable, this means fastembed cannot load models that are already present in the local cache.

## Fix

Set `local_files_only=True` at the top of `download_model()` when `HF_HUB_OFFLINE` is set to a truthy value. This ensures:

1. The HF local cache pass uses `snapshot_download(..., local_files_only=True)` — works if the model is cached
2. `retries` is set to 1 (no unnecessary retries)
3. The retry loop skips the network-dependent HF path (`hf_source and not local_files_only` is `False`)
4. `retrieve_model_gcs()` only checks for local `fast-*` directories without downloading
5. Zero network traffic

The truthy value check (`1`, `TRUE`, `YES`, `ON`, case-insensitive) aligns with `huggingface_hub`'s own parsing of `HF_HUB_OFFLINE`.

## Context

This was discovered while deploying NeMo Guardrails on Red Hat OpenShift AI in corporate air-gapped environments. With `HF_HUB_OFFLINE=1`, fastembed's `all-MiniLM-L6-v2` model (pre-cached in the container image during build) could not be loaded — the HF path raised an offline error, and the GCS fallback tried to download from `storage.googleapis.com` which was also blocked.

---

### All Submissions:

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New Feature Submissions:

- [x] Does your submission pass the existing tests?
- [ ] Have you added tests for your feature?
- [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?