### PR TITLE
Add intfloat/multilingual-e5-large-instruct model support

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -180,6 +180,19 @@ supported_onnx_models: list[DenseModelDescription] = [
         sources=ModelSource(hf="jinaai/jina-clip-v1"),
         model_file="onnx/text_model.onnx",
     ),
+    DenseModelDescription(
+        model="intfloat/multilingual-e5-large-instruct",
+        dim=1024,
+        description=(
+            "Text embeddings, Unimodal (text), Multilingual, 512 input tokens truncation, "
+            "Prefixes for queries/documents: necessary, 2024 year."
+        ),
+        license="mit",
+        size_in_GB=2.25,
+        sources=ModelSource(hf="intfloat/multilingual-e5-large-instruct"),
+        model_file="onnx/model.onnx",
+        additional_files=["onnx/model.onnx_data"]
+    )
 ]
 
 

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -36,6 +36,7 @@ CANONICAL_VECTOR_VALUES = {
         [0.0361, 0.1862, 0.2776, 0.2461, -0.1904]
     ),
     "intfloat/multilingual-e5-large": np.array([0.4544, -0.0968, 0.1054, -1.3753, 0.1500]),
+    "intfloat/multilingual-e5-large-instruct": np.array([0.01044649, 0.02897520, 0.00060697, -0.04193532, 0.02606634]),
     "sentence-transformers/paraphrase-multilingual-mpnet-base-v2": np.array(
         [0.0047, 0.1334, -0.0102, 0.0714, 0.1930]
     ),


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New models submission:
* [x] Have you added an explanation of why it's important to include this model?

Closes #140. This was previously attempted in #181 but was not completed. `intfloat/multilingual-e5-large-instruct` is a state-of-the-art multilingual embedding model that supports instruction-based embeddings across 100+ languages. It outperforms `multilingual-e5-large` on MTEB benchmarks and is widely used for multilingual retrieval tasks. Personally, multilingual-e5-large-instruct is very much better in retrieval tasks(even with other supported languages) than multilingual-e5-large.

* [x] Have you added tests for the new model? Were canonical values for tests computed via the original model?

Yes, canonical values were computed using fastembed itself (not sentence-transformers).

* [x] Have you added the code snippet for how canonical values were computed?
```python
from fastembed import TextEmbedding
import numpy as np

model = TextEmbedding(model_name="intfloat/multilingual-e5-large-instruct")
docs = ["hello world", "flag embedding"]
embeddings = list(model.embed(docs))
vec = np.array(embeddings[0])
print("First 5 values:", vec[:5].tolist())
```

* [x] Have you successfully ran tests with your changes locally?

Yes, verified via a standalone script that the canonical vector matches within `atol=1e-3`.
cc @hh-space-invader @joein

> Note: #181 previously attempted to add this model but required a manual ONNX export as official ONNX support was unavailable at the time(I believe). The ONNX model is now officially available on the [model's HuggingFace page](https://huggingface.co/intfloat/multilingual-e5-large-instruct), making this a clean addition without any manual export.