### PR TITLE
fix: use original jina de model instead of fp16 due to onnxruntime up…

### DIFF
--- a/fastembed/text/pooled_normalized_embedding.py
+++ b/fastembed/text/pooled_normalized_embedding.py
@@ -57,7 +57,7 @@ supported_pooled_normalized_models: list[DenseModelDescription] = [
             "Prefixes for queries/documents: not necessary, 2024 year."
         ),
         license="apache-2.0",
-        size_in_GB=0.32,
+        size_in_GB=0.64,
         sources=ModelSource(hf="jinaai/jina-embeddings-v2-base-de"),
         model_file="onnx/model.onnx",
     ),

--- a/fastembed/text/pooled_normalized_embedding.py
+++ b/fastembed/text/pooled_normalized_embedding.py
@@ -59,7 +59,7 @@ supported_pooled_normalized_models: list[DenseModelDescription] = [
         license="apache-2.0",
         size_in_GB=0.32,
         sources=ModelSource(hf="jinaai/jina-embeddings-v2-base-de"),
-        model_file="onnx/model_fp16.onnx",
+        model_file="onnx/model.onnx",
     ),
     DenseModelDescription(
         model="jinaai/jina-embeddings-v2-base-code",

--- a/fastembed/text/text_embedding.py
+++ b/fastembed/text/text_embedding.py
@@ -90,23 +90,9 @@ class TextEmbedding(TextEmbeddingBase):
         **kwargs: Any,
     ):
         super().__init__(model_name, cache_dir, threads, **kwargs)
-        if model_name.lower() == "nomic-ai/nomic-embed-text-v1.5-Q".lower():
+        if model_name.lower() == "jinaai/jina-embeddings-v2-base-de":
             warnings.warn(
-                "The model 'nomic-ai/nomic-embed-text-v1.5-Q' has been updated on HuggingFace. Please review "
-                "the latest documentation on HF and release notes to ensure compatibility with your workflow. ",
-                UserWarning,
-                stacklevel=2,
-            )
-        if model_name.lower() in {
-            "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2".lower(),
-            "thenlper/gte-large".lower(),
-            "intfloat/multilingual-e5-large".lower(),
-            "sentence-transformers/paraphrase-multilingual-mpnet-base-v2".lower(),
-        }:
-            warnings.warn(
-                f"The model {model_name} now uses mean pooling instead of CLS embedding. "
-                f"In order to preserve the previous behaviour, consider either pinning fastembed version to 0.5.1 or "
-                "using `add_custom_model` functionality.",
+                "The model 'jinaai/jina-embeddings-v2-base-de' used to run with fp16 model, but due to onnxruntime updates, now it runs with the original fp32 model.",
                 UserWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
Starting from `onnxruntime` 1.23, `model_fp16.onnx` started failing with `onnxruntime` not supporting a custom layer in fp16 version of `jinaai/jina-embeddings-v2-base-de`, in order to mitigate this issue, I propose to replace fp16 model with the original fp32