### PR TITLE
docs: document model cache configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,33 @@ len(embeddings_list[0]) # Vector of 384 dimensions
 
 Fastembed supports a variety of models for different tasks and modalities.
 The list of all the available models can be found [here](https://qdrant.github.io/fastembed/examples/Supported_Models/)
+
+## Model cache
+
+FastEmbed downloads model files the first time a model is initialized. By default,
+the cache directory is named `fastembed_cache` inside the system temporary
+directory. If that location is cleaned up between runs, models may need to be
+downloaded again.
+
+To use a persistent location, pass `cache_dir` when creating a model:
+
+```python
+from fastembed import TextEmbedding
+
+embedding_model = TextEmbedding(cache_dir="./fastembed_cache")
+```
+
+You can also set the `FASTEMBED_CACHE_PATH` environment variable to choose the
+default cache location for model classes that do not receive an explicit
+`cache_dir`:
+
+```bash
+export FASTEMBED_CACHE_PATH=/var/cache/fastembed
+```
+
+When running FastEmbed in a container, mount the chosen cache directory as a
+volume so downloaded model files survive container restarts.
+
 ### 🎒 Dense text embeddings
 
 ```python

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,32 @@ embedding_model = TextEmbedding()
 embeddings: list[np.ndarray] = embedding_model.embed(documents)
 ```
 
+## Model cache
+
+FastEmbed downloads model files the first time a model is initialized. By default,
+the cache directory is named `fastembed_cache` inside the system temporary
+directory. If that location is cleaned up between runs, models may need to be
+downloaded again.
+
+To use a persistent location, pass `cache_dir` when creating a model:
+
+```python
+from fastembed import TextEmbedding
+
+embedding_model = TextEmbedding(cache_dir="./fastembed_cache")
+```
+
+You can also set the `FASTEMBED_CACHE_PATH` environment variable to choose the
+default cache location for model classes that do not receive an explicit
+`cache_dir`:
+
+```bash
+export FASTEMBED_CACHE_PATH=/var/cache/fastembed
+```
+
+When running FastEmbed in a container, mount the chosen cache directory as a
+volume so downloaded model files survive container restarts.
+
 ## Usage with Qdrant
 
 Installation with Qdrant Client in Python:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### Summary

* Document the current FastEmbed model cache default in `README.md` and `docs/index.md`.
* Show how to use a persistent cache with `cache_dir`.
* Show how to set `FASTEMBED_CACHE_PATH` for a default cache location, and mention mounting that directory for container restarts.

Helps #569.

### Validation

* `git diff --check`
* `git show --check --stat --oneline HEAD`
* `rg -n "Model cache|FASTEMBED_CACHE_PATH|cache_dir=|fastembed_cache" README.md docs/index.md fastembed/common/utils.py`
* Tests not run locally; documentation-only change.
