### PR TITLE
docs: align MiniLM truncation metadata

### DIFF
--- a/fastembed/text/pooled_embedding.py
+++ b/fastembed/text/pooled_embedding.py
@@ -50,7 +50,7 @@ supported_pooled_models: list[DenseModelDescription] = [
         model="sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2",
         dim=384,
         description=(
-            "Text embeddings, Unimodal (text), Multilingual (~50 languages), 512 input tokens truncation, "
+            "Text embeddings, Unimodal (text), Multilingual (~50 languages), 128 input tokens truncation, "
             "Prefixes for queries/documents: not necessary, 2019 year."
         ),
         license="apache-2.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

### Summary

- Align the supported-model description for `sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2` with its 128-token default truncation length.
- Keep the model metadata in `TextEmbedding.list_supported_models()` consistent with the upstream model architecture noted in #531.

Fixes #531.

### Validation

- `git diff --check`
- `git show --check --stat --oneline HEAD`
- Static search for the MiniLM model description in `fastembed/text/pooled_embedding.py`
- Not run locally: tests, docs build, pre-commit