### PR TITLE
fix case insensitive lookup for custom text models

### DIFF
--- a/fastembed/text/custom_text_embedding.py
+++ b/fastembed/text/custom_text_embedding.py
@@ -50,8 +50,10 @@ class CustomTextEmbedding(OnnxTextEmbedding):
             specific_model_path=specific_model_path,
             **kwargs,
         )
-        self._pooling = self.POSTPROCESSING_MAPPING[model_name].pooling
-        self._normalization = self.POSTPROCESSING_MAPPING[model_name].normalization
+        self._pooling = self.POSTPROCESSING_MAPPING[self.model_description.model].pooling
+        self._normalization = self.POSTPROCESSING_MAPPING[
+            self.model_description.model
+        ].normalization
 
     @classmethod
     def _list_supported_models(cls) -> list[DenseModelDescription]:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -179,6 +179,25 @@ def test_mock_add_custom_models():
     CustomTextEmbedding.POSTPROCESSING_MAPPING.clear()
 
 
+def test_custom_text_model_lookup_is_case_insensitive():
+    model_name = "Org/Model"
+
+    TextEmbedding.add_custom_model(
+        model_name,
+        pooling=PoolingType.MEAN,
+        normalization=True,
+        sources=ModelSource(hf="artificial"),
+        dim=5,
+        size_in_gb=0.1,
+    )
+
+    model = TextEmbedding("org/model", lazy_load=True, specific_model_path="./")
+
+    assert isinstance(model.model, CustomTextEmbedding)
+    assert model.model._pooling == PoolingType.MEAN
+    assert model.model._normalization is True
+
+
 def test_do_not_add_existing_model():
     existing_base_model = "sentence-transformers/all-MiniLM-L6-v2"
     custom_model_name = "intfloat/multilingual-e5-small"


### PR DESCRIPTION
Fixes #650 
### Checklist

- [x] Have you followed the guidelines in the Contributing document?
- [x] Have you checked that there are no existing open PRs for the same issue?
- [x] Does the change pass tests locally?
- [x] Have you added a regression test for the fix?

## Summary

Custom models can be registered using one casing (e.g. `Org/Model`) and later instantiated using a different casing (e.g. `org/model`). `TextEmbedding` already resolves models case-insensitively, but `CustomTextEmbedding` later looked up the postprocessing configuration using the original user-provided model name, which could result in a `KeyError`.

This change uses the canonical resolved model name from `self.model_description.model` when retrieving the postprocessing configuration.

## Changes

- Fix custom text model postprocessing lookup to use the canonical resolved model name.
- Add a regression test covering mixed-case registration and instantiation.

## Reproduction

### Before

1. Register a custom model as `Org/Model`.
2. Instantiate `TextEmbedding("org/model")`.
3. Construction can fail with `KeyError`.

### After

1. Register a custom model as `Org/Model`.
2. Instantiate `TextEmbedding("org/model")`.
3. Construction succeeds and uses the correct postprocessing configuration.

## Testing

- Added `test_custom_text_model_lookup_is_case_insensitive`.
- Verified with:

```bash
poetry run pytest tests/test_custom_models.py -k custom_text_model_lookup_is_case_insensitive -q