### PR TITLE
fix: correct resize dimension order for non-square images

### DIFF
--- a/fastembed/image/transform/functional.py
+++ b/fastembed/image/transform/functional.py
@@ -98,7 +98,8 @@ def resize(
     resample: int | Image.Resampling = Image.Resampling.BILINEAR,
 ) -> Image.Image:
     if isinstance(size, tuple):
-        return image.resize(size, resample)
+        height, width = size
+        return image.resize((width, height), resample)  
 
     height, width = image.height, image.width
     short, long = (width, height) if width <= height else (height, width)

--- a/tests/test_image_onnx_embeddings.py
+++ b/tests/test_image_onnx_embeddings.py
@@ -173,3 +173,24 @@ def test_session_options(model_cache, model_name) -> None:
         model = ImageEmbedding(model_name=model_name, enable_cpu_mem_arena=False)
         session_options = model.model.model.get_session_options()
         assert session_options.enable_cpu_mem_arena is False
+
+def test_resize_dimension_order():
+     from PIL import Image
+     from fastembed.image.transform.operators import Resize
+
+     # Define target dimensions: Height=100, Width=200
+     # FastEmbed's Resize transform semantically expects (height, width)
+     target_height, target_width = 100, 200
+     resizer = Resize(size=(target_height, target_width))
+
+        # Create a square 50x50 dummy image
+     img = Image.new("RGB", (50, 50))
+   
+        # Apply Resize transform (expects list, returns list)
+     resized_img = resizer([img])[0]
+   
+        # PIL's image.size property returns (width, height)
+        # Buggy: produces (100, 200) -> width=100, height=200
+        # Correct: should produce (200, 100) -> width=200, height=100
+     assert resized_img.size == (target_width, target_height), \
+        f"Expected size (W={target_width}, H={target_height}), but got {resized_img.size}"


### PR DESCRIPTION
Fixes #649
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?


Fixes an issue in the image `Resize` transform where non-square dimensions were passed directly to Pillow without converting FastEmbed's internal `(height, width)` representation to Pillow's expected `(width, height)` format.

The issue is currently masked because supported image models use square dimensions, but non-square image processor configurations produce swapped output sizes.

## Changes

* Convert `(height, width)` to `(width, height)` before calling `PIL.Image.resize`.
* Add a regression test covering non-square resize dimensions.

## Validation

Added a regression test demonstrating the issue:

* Before the fix, `Resize(size=(100, 200))` produced an image with size `(100, 200)`.
* After the fix, the same configuration correctly produces `(200, 100)`.

The regression test fails on the previous implementation and passes with this change.
