### PR TITLE
new: support pluggable stemmer and inline stopwords for Bm25

### DIFF
--- a/fastembed/sparse/bm25.py
+++ b/fastembed/sparse/bm25.py
@@ -2,7 +2,7 @@ import os
 from collections import defaultdict
 from multiprocessing import get_all_start_methods
 from pathlib import Path
-from typing import Any, Iterable, Type
+from typing import Any, Iterable, Protocol, Type, runtime_checkable
 
 import mmh3
 import numpy as np
@@ -20,6 +20,17 @@ from fastembed.sparse.sparse_embedding_base import (
 )
 from fastembed.sparse.utils.tokenizer import SimpleTokenizer
 from fastembed.common.model_description import SparseModelDescription, ModelSource
+
+
+@runtime_checkable
+class Stemmer(Protocol):
+    """Protocol for custom stemmers pluggable into Bm25.
+
+    Any object exposing a `stem_word` method, e.g. `py_rust_stemmers.SnowballStemmer`,
+    satisfies this protocol.
+    """
+
+    def stem_word(self, word: str) -> str: ...
 
 
 supported_languages = [
@@ -84,6 +95,12 @@ class Bm25(SparseTextEmbeddingBase):
         avg_len (float, optional): The average length of the documents in the corpus. Defaults to 256.0.
         language (str): Specifies the language for the stemmer.
         disable_stemmer (bool): Disable the stemmer.
+        stemmer (Stemmer, optional): A custom stemmer to use instead of the default SnowballStemmer.
+            Any object with a `stem_word(word: str) -> str` method. When provided, the `language`
+            is not required to be in the list of supported languages, which enables languages
+            without a Snowball algorithm (e.g. Polish). Defaults to None.
+        stopwords (Iterable[str], optional): Inline stopwords to use instead of the stopwords file
+            shipped with the model for the chosen language. Defaults to None.
     Raises:
         ValueError: If the model_name is not in the format <org>/<model> e.g. BAAI/bge-base-en.
     """
@@ -99,14 +116,19 @@ class Bm25(SparseTextEmbeddingBase):
         token_max_length: int = 40,
         disable_stemmer: bool = False,
         specific_model_path: str | None = None,
+        stemmer: Stemmer | None = None,
+        stopwords: Iterable[str] | None = None,
         **kwargs: Any,
     ):
         super().__init__(model_name, cache_dir, **kwargs)
 
-        if language not in supported_languages:
+        if stemmer is None and language not in supported_languages:
             raise ValueError(f"{language} language is not supported")
         else:
             self.language = language
+
+        self._custom_stemmer = stemmer
+        self._custom_stopwords = set(stopwords) if stopwords is not None else None
 
         self.k = k
         self.b = b
@@ -128,11 +150,17 @@ class Bm25(SparseTextEmbeddingBase):
         self.disable_stemmer = disable_stemmer
 
         if disable_stemmer:
-            self.stopwords: set[str] = set()
-            self.stemmer = None
+            self.stopwords: set[str] = (
+                self._custom_stopwords if self._custom_stopwords is not None else set()
+            )
+            self.stemmer: Stemmer | None = None
         else:
-            self.stopwords = set(self._load_stopwords(self._model_dir, self.language))
-            self.stemmer = SnowballStemmer(language)
+            self.stopwords = (
+                self._custom_stopwords
+                if self._custom_stopwords is not None
+                else set(self._load_stopwords(self._model_dir, self.language))
+            )
+            self.stemmer = stemmer if stemmer is not None else SnowballStemmer(language)
 
         self.tokenizer = SimpleTokenizer
 
@@ -191,6 +219,8 @@ class Bm25(SparseTextEmbeddingBase):
                 "language": self.language,
                 "token_max_length": self.token_max_length,
                 "disable_stemmer": self.disable_stemmer,
+                "stemmer": self._custom_stemmer,
+                "stopwords": self._custom_stopwords,
                 "local_files_only": local_files_only,
                 "specific_model_path": specific_model_path,
             }

--- a/tests/test_sparse_embeddings.py
+++ b/tests/test_sparse_embeddings.py
@@ -311,6 +311,64 @@ def test_disable_stemmer_behavior(disable_stemmer: bool) -> None:
     assert result == expected, f"Expected {expected}, but got {result}"
 
 
+class _TruncatingStemmer:
+    """A trivial fake stemmer that truncates words to their first three characters."""
+
+    def stem_word(self, word: str) -> str:
+        return word[:3]
+
+
+def test_custom_stemmer_is_used() -> None:
+    model = Bm25("Qdrant/bm25", language="english", stemmer=_TruncatingStemmer())
+
+    result = model._stem(["running", "jumped", "documents"])
+
+    assert result == ["run", "jum", "doc"], f"Custom stemmer was not applied, got {result}"
+
+
+def test_default_stemmer_path_unchanged() -> None:
+    model = Bm25("Qdrant/bm25", language="english")
+
+    result = model._stem(["running", "jumped", "documents"])
+
+    assert result == ["run", "jump", "document"], f"Default Snowball path changed, got {result}"
+
+
+def test_custom_stemmer_enables_unsupported_language() -> None:
+    class _FakePolishStemmer:
+        def stem_word(self, word: str) -> str:
+            for suffix in ("ami", "ach"):
+                if word.endswith(suffix):
+                    return word[: -len(suffix)]
+            return word
+
+    # without a custom stemmer, unsupported languages are still rejected
+    with pytest.raises(ValueError):
+        Bm25("Qdrant/bm25", language="polish")
+
+    model = Bm25(
+        "Qdrant/bm25",
+        language="polish",
+        stemmer=_FakePolishStemmer(),
+        stopwords=["i", "w"],
+    )
+
+    assert model.stopwords == {"i", "w"}
+
+    result = model._stem(["kotami", "domach", "w"])
+
+    assert result == ["kot", "dom"], f"Expected ['kot', 'dom'], but got {result}"
+
+
+def test_inline_stopwords_override_file_stopwords() -> None:
+    model = Bm25("Qdrant/bm25", language="english", stopwords=["fox"])
+
+    result = model._stem(["the", "fox"])
+
+    # "the" is no longer a stopword, "fox" is
+    assert result == ["the"], f"Inline stopwords were not applied, got {result}"
+
+
 def test_if_splade_query_embed_is_inference_free() -> None:
     is_ci = os.getenv("CI")
     model = SparseTextEmbedding(


### PR DESCRIPTION
Closes #654, requested by @pjastrzebskiwelyo.

Adds a `stemmer` parameter to `Bm25`: any object with a `stem_word(word: str) -> str` method (a small `Stemmer` protocol, satisfied by `py_rust_stemmers.SnowballStemmer` among others). When a custom stemmer is provided, the language check is relaxed, which enables languages without a Snowball algorithm such as Polish. An optional `stopwords` parameter lets callers pass inline stopwords instead of the file shipped with the model, which those languages need too.

No new dependencies, and defaults are unchanged: without the new parameters, behavior is byte-for-byte the same (there is a test pinning the default Snowball path).

New tests cover a custom stemmer being used, an unsupported language working with one, inline stopwords overriding the file-based set, and the default path staying unchanged. They fail without the change; the sparse embedding suite passes with it.
