### PR TITLE
feat: add Arctic Embed 2.0 (M and L) models

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -169,6 +169,32 @@ supported_onnx_models: list[DenseModelDescription] = [
         model_file="onnx/model.onnx",
     ),
     DenseModelDescription(
+        model="Snowflake/snowflake-arctic-embed-m-v2.0",
+        dim=768,
+        description=(
+            "Text embeddings, Unimodal (text), Multilingual (100+ languages), "
+            "8192 input tokens truncation, "
+            "Prefixes for queries/documents: not necessary, 2025 year."
+        ),
+        license="apache-2.0",
+        size_in_GB=1.14,
+        sources=ModelSource(hf="Snowflake/snowflake-arctic-embed-m-v2.0"),
+        model_file="onnx/model.onnx",
+    ),
+    DenseModelDescription(
+        model="Snowflake/snowflake-arctic-embed-l-v2.0",
+        dim=1024,
+        description=(
+            "Text embeddings, Unimodal (text), Multilingual (100+ languages), "
+            "8192 input tokens truncation, "
+            "Prefixes for queries/documents: not necessary, 2025 year."
+        ),
+        license="apache-2.0",
+        size_in_GB=2.11,
+        sources=ModelSource(hf="Snowflake/snowflake-arctic-embed-l-v2.0"),
+        model_file="onnx/model.onnx",
+    ),
+    DenseModelDescription(
         model="jinaai/jina-clip-v1",
         dim=768,
         description=(

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -174,7 +174,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         description=(
             "Text embeddings, Unimodal (text), Multilingual (74 languages), "
             "8192 input tokens truncation, "
-            "Prefixes for queries/documents: query: prefix recommended for retrieval queries, 2025 year."
+            "Prefixes for queries/documents: `query: ` prefix should be prepended to retrieval queries by the caller, 2025 year."
         ),
         license="apache-2.0",
         size_in_GB=1.14,
@@ -187,7 +187,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         description=(
             "Text embeddings, Unimodal (text), Multilingual (74 languages), "
             "8192 input tokens truncation, "
-            "Prefixes for queries/documents: query: prefix recommended for retrieval queries, 2025 year."
+            "Prefixes for queries/documents: `query: ` prefix should be prepended to retrieval queries by the caller, 2025 year."
         ),
         license="apache-2.0",
         size_in_GB=2.11,

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -172,9 +172,9 @@ supported_onnx_models: list[DenseModelDescription] = [
         model="Snowflake/snowflake-arctic-embed-m-v2.0",
         dim=768,
         description=(
-            "Text embeddings, Unimodal (text), Multilingual (100+ languages), "
+            "Text embeddings, Unimodal (text), Multilingual (74 languages), "
             "8192 input tokens truncation, "
-            "Prefixes for queries/documents: not necessary, 2025 year."
+            "Prefixes for queries/documents: query: prefix recommended for retrieval queries, 2025 year."
         ),
         license="apache-2.0",
         size_in_GB=1.14,
@@ -185,14 +185,15 @@ supported_onnx_models: list[DenseModelDescription] = [
         model="Snowflake/snowflake-arctic-embed-l-v2.0",
         dim=1024,
         description=(
-            "Text embeddings, Unimodal (text), Multilingual (100+ languages), "
+            "Text embeddings, Unimodal (text), Multilingual (74 languages), "
             "8192 input tokens truncation, "
-            "Prefixes for queries/documents: not necessary, 2025 year."
+            "Prefixes for queries/documents: query: prefix recommended for retrieval queries, 2025 year."
         ),
         license="apache-2.0",
         size_in_GB=2.11,
         sources=ModelSource(hf="Snowflake/snowflake-arctic-embed-l-v2.0"),
         model_file="onnx/model.onnx",
+        additional_files=["onnx/model.onnx_data"],
     ),
     DenseModelDescription(
         model="jinaai/jina-clip-v1",

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -65,6 +65,12 @@ CANONICAL_VECTOR_VALUES = {
         [0.0080, -0.0266, -0.0335, 0.0282, 0.0143]
     ),
     "snowflake/snowflake-arctic-embed-l": np.array([0.0189, -0.0673, 0.0183, 0.0124, 0.0146]),
+    "Snowflake/snowflake-arctic-embed-m-v2.0": np.array(
+        [0.00531, 0.049518, -0.1072, -0.005782, -0.009776]
+    ),
+    "Snowflake/snowflake-arctic-embed-l-v2.0": np.array(
+        [-0.015422, 0.015617, -0.023605, 0.011296, 0.003507]
+    ),
     "Qdrant/clip-ViT-B-32-text": np.array([0.0083, 0.0103, -0.0138, 0.0199, -0.0069]),
     "thenlper/gte-base": np.array([0.0038, 0.0355, 0.0181, 0.0092, 0.0654]),
     "jinaai/jina-clip-v1": np.array([-0.0862, -0.0101, -0.0056, 0.0375, -0.0472]),


### PR DESCRIPTION
Add Snowflake/snowflake-arctic-embed-m-v2.0 (768 dims, GTE-based, multilingual, 8192 tokens) and Snowflake/snowflake-arctic-embed-l-v2.0 (1024 dims, XLM-RoBERTa-based, multilingual, 8192 tokens).

Arctic Embed 2.0 adds multilingual support (100+ languages) without sacrificing English performance. Both models support 8192 token context (16x longer than Arctic Embed 1.0's 512 tokens).

Canonical vectors generated via:
- M: ONNX runtime inference (same execution path as fastembed)
- L: sentence-transformers + PyTorch (reference implementation)

Both models use Apache-2.0 license and are available on HuggingFace with pre-built ONNX exports.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### New Feature Submissions:

* [x] Does your submission pass the existing tests?
* [x] Have you added tests for your feature?
* [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

### New models submission:

* [x] Have you added an explanation of why it's important to include this model?
* [x] Have you added tests for the new model? Were canonical values for tests computed via the original model?
* [x] Have you added the code snippet for how canonical values were computed?
* [x] Have you successfully ran tests with your changes locally?
