### PR TITLE
fix: resolve custom embedding postprocessing by canonical model name

### DIFF
--- a/fastembed/text/custom_text_embedding.py
+++ b/fastembed/text/custom_text_embedding.py
@@ -50,8 +50,11 @@ class CustomTextEmbedding(OnnxTextEmbedding):
             specific_model_path=specific_model_path,
             **kwargs,
         )
-        self._pooling = self.POSTPROCESSING_MAPPING[model_name].pooling
-        self._normalization = self.POSTPROCESSING_MAPPING[model_name].normalization
+        # model_name is resolved case-insensitively by the parent, so look up
+        # postprocessing by the canonical name rather than the raw argument.
+        canonical_model_name = self.model_description.model
+        self._pooling = self.POSTPROCESSING_MAPPING[canonical_model_name].pooling
+        self._normalization = self.POSTPROCESSING_MAPPING[canonical_model_name].normalization
 
     @classmethod
     def _list_supported_models(cls) -> list[DenseModelDescription]:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -179,6 +179,34 @@ def test_mock_add_custom_models():
     CustomTextEmbedding.POSTPROCESSING_MAPPING.clear()
 
 
+def test_custom_model_case_insensitive_postprocessing():
+    registered_name = "Org/Model"
+    source = ModelSource(hf="artificial")
+
+    TextEmbedding.add_custom_model(
+        registered_name,
+        pooling=PoolingType.MEAN,
+        normalization=True,
+        sources=source,
+        dim=5,
+        size_in_gb=0.1,
+    )
+
+    # Registering with one casing and instantiating with another must not raise
+    # KeyError: postprocessing is looked up by the canonical resolved name.
+    custom_text_embedding = CustomTextEmbedding(
+        registered_name.lower(),
+        lazy_load=True,
+        specific_model_path="./",  # disable model downloading and loading
+    )
+
+    assert custom_text_embedding._pooling == PoolingType.MEAN
+    assert custom_text_embedding._normalization is True
+
+    CustomTextEmbedding.SUPPORTED_MODELS.clear()
+    CustomTextEmbedding.POSTPROCESSING_MAPPING.clear()
+
+
 def test_do_not_add_existing_model():
     existing_base_model = "sentence-transformers/all-MiniLM-L6-v2"
     custom_model_name = "intfloat/multilingual-e5-small"


### PR DESCRIPTION
Fixes #650. `TextEmbedding` resolves model names case-insensitively, but `CustomTextEmbedding.__init__` then looked up the postprocessing config with the raw user-provided `model_name`. So registering a model as `Org/Model` and instantiating it as `org/model` blew up with `KeyError: 'org/model'` even though the parent had already resolved the name fine.

Switched the lookup to `self.model_description.model` — the canonical name the parent resolves to — so registration and instantiation stay case-insensitive.

Added a test that registers under one casing and instantiates under another; it reproduced the `KeyError` before the change and passes now. It uses the existing `lazy_load=True` / `specific_model_path="./"` trick so nothing gets downloaded. `ruff format`, `mypy` and the offline custom-model tests are clean.
