### PR TITLE
fix: terminate interrupted parallel workers

### DIFF
--- a/fastembed/parallel_processor.py
+++ b/fastembed/parallel_processor.py
@@ -153,6 +153,7 @@ class ParallelWorkerPool:
     def semi_ordered_map(
         self, stream: Iterable[Any], *args: Any, **kwargs: Any
     ) -> Iterable[tuple[int, Any]]:
+        completed = False
         try:
             self.start(**kwargs)
 
@@ -196,10 +197,19 @@ class ParallelWorkerPool:
                     raise RuntimeError("Thread unexpectedly terminated")
                 yield out_item
                 read += 1
+            completed = True
         finally:
             assert self.input_queue is not None, "Input queue is None"
             assert self.output_queue is not None, "Output queue is None"
-            self.join()
+            if completed:
+                self.join()
+            else:
+                # The generator may be closed before the input stream is exhausted (for
+                # example, when a caller only consumes a prefix of the embeddings). In that
+                # case workers have not necessarily received their stop signals and a normal
+                # join would wait forever for processes blocked on the input queue.
+                self.emergency_shutdown = True
+                self.join_or_terminate()
             self.input_queue.close()
             self.output_queue.close()
             if self.emergency_shutdown:

--- a/fastembed/parallel_processor.py
+++ b/fastembed/parallel_processor.py
@@ -111,6 +111,7 @@ class ParallelWorkerPool:
         self.num_active_workers: BaseValue | None = None
 
     def start(self, **kwargs: Any) -> None:
+        self.emergency_shutdown = False
         self.input_queue = self.ctx.Queue(self.queue_size)
         self.output_queue = self.ctx.Queue(self.queue_size)
 
@@ -241,6 +242,7 @@ class ParallelWorkerPool:
             process.join(timeout=timeout)
             if process.is_alive():
                 process.terminate()
+                process.join(timeout=timeout)
         self.processes.clear()
 
     def join(self) -> None:

--- a/tests/test_parallel_processor.py
+++ b/tests/test_parallel_processor.py
@@ -106,6 +106,8 @@ def test_reused_pool_returns_to_graceful_queue_cleanup():
     first_results.close()
 
     assert pool.emergency_shutdown is True
+    assert first_process.join.call_args_list == [call(timeout=1), call(timeout=1)]
+    first_process.terminate.assert_called_once_with()
     first_input_queue.cancel_join_thread.assert_called_once_with()
     first_output_queue.cancel_join_thread.assert_called_once_with()
 

--- a/tests/test_parallel_processor.py
+++ b/tests/test_parallel_processor.py
@@ -1,5 +1,6 @@
+from multiprocessing import get_context
 from queue import Empty
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 import pytest
 
@@ -40,7 +41,7 @@ def test_closing_partial_parallel_iterator_terminates_workers(monkeypatch):
     assert next(results) == "result"
     results.close()
 
-    process.join.assert_called_once_with(timeout=1)
+    assert process.join.call_args_list == [call(timeout=1), call(timeout=1)]
     process.terminate.assert_called_once_with()
     input_queue.cancel_join_thread.assert_called_once_with()
     output_queue.cancel_join_thread.assert_called_once_with()
@@ -56,7 +57,7 @@ def test_parallel_iterator_terminates_workers_when_input_raises(monkeypatch):
     with pytest.raises(RuntimeError, match="stream failed"):
         list(pool.semi_ordered_map(failing_stream()))
 
-    process.join.assert_called_once_with(timeout=1)
+    assert process.join.call_args_list == [call(timeout=1), call(timeout=1)]
     process.terminate.assert_called_once_with()
     input_queue.cancel_join_thread.assert_called_once_with()
     output_queue.cancel_join_thread.assert_called_once_with()
@@ -71,3 +72,47 @@ def test_exhausted_parallel_iterator_joins_workers_gracefully(monkeypatch):
     process.terminate.assert_not_called()
     input_queue.join_thread.assert_called_once_with()
     output_queue.join_thread.assert_called_once_with()
+
+
+def test_reused_pool_returns_to_graceful_queue_cleanup():
+    pool = ParallelWorkerPool(1, EchoWorker)
+    ctx = MagicMock()
+    pool.ctx = ctx
+
+    first_input_queue = MagicMock()
+    first_output_queue = MagicMock()
+    first_output_queue.get_nowait.return_value = (0, "first result")
+    second_input_queue = MagicMock()
+    second_output_queue = MagicMock()
+    second_output_queue.get_nowait.return_value = (0, "second result")
+    first_process = MagicMock()
+    first_process.is_alive.return_value = True
+    second_process = MagicMock()
+
+    ctx.Queue.side_effect = [
+        first_input_queue,
+        first_output_queue,
+        second_input_queue,
+        second_output_queue,
+    ]
+    ctx.Value.side_effect = [
+        get_context().Value("i", 1),
+        get_context().Value("i", 1),
+    ]
+    ctx.Process.side_effect = [first_process, second_process]
+
+    first_results = pool.ordered_map(["first input"])
+    assert next(first_results) == "first result"
+    first_results.close()
+
+    assert pool.emergency_shutdown is True
+    first_input_queue.cancel_join_thread.assert_called_once_with()
+    first_output_queue.cancel_join_thread.assert_called_once_with()
+
+    assert list(pool.semi_ordered_map(["second input"])) == [(0, "second result")]
+
+    assert pool.emergency_shutdown is False
+    second_input_queue.join_thread.assert_called_once_with()
+    second_output_queue.join_thread.assert_called_once_with()
+    second_input_queue.cancel_join_thread.assert_not_called()
+    second_output_queue.cancel_join_thread.assert_not_called()

--- a/tests/test_parallel_processor.py
+++ b/tests/test_parallel_processor.py
@@ -1,0 +1,73 @@
+from queue import Empty
+from unittest.mock import MagicMock
+
+import pytest
+
+from fastembed.parallel_processor import ParallelWorkerPool, Worker
+
+
+class EchoWorker(Worker):
+    @classmethod
+    def start(cls, **kwargs):
+        return cls()
+
+    def process(self, items):
+        yield from items
+
+
+def make_stubbed_pool(monkeypatch):
+    pool = ParallelWorkerPool(1, EchoWorker)
+    input_queue = MagicMock()
+    output_queue = MagicMock()
+    output_queue.get_nowait.side_effect = Empty
+    output_queue.get.return_value = (0, "result")
+    process = MagicMock()
+    process.is_alive.return_value = True
+
+    def start(**kwargs):
+        pool.input_queue = input_queue
+        pool.output_queue = output_queue
+        pool.processes = [process]
+
+    monkeypatch.setattr(pool, "start", start)
+    return pool, input_queue, output_queue, process
+
+
+def test_closing_partial_parallel_iterator_terminates_workers(monkeypatch):
+    pool, input_queue, output_queue, process = make_stubbed_pool(monkeypatch)
+    results = pool.ordered_map(["input"])
+
+    assert next(results) == "result"
+    results.close()
+
+    process.join.assert_called_once_with(timeout=1)
+    process.terminate.assert_called_once_with()
+    input_queue.cancel_join_thread.assert_called_once_with()
+    output_queue.cancel_join_thread.assert_called_once_with()
+
+
+def test_parallel_iterator_terminates_workers_when_input_raises(monkeypatch):
+    pool, input_queue, output_queue, process = make_stubbed_pool(monkeypatch)
+
+    def failing_stream():
+        yield "input"
+        raise RuntimeError("stream failed")
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        list(pool.semi_ordered_map(failing_stream()))
+
+    process.join.assert_called_once_with(timeout=1)
+    process.terminate.assert_called_once_with()
+    input_queue.cancel_join_thread.assert_called_once_with()
+    output_queue.cancel_join_thread.assert_called_once_with()
+
+
+def test_exhausted_parallel_iterator_joins_workers_gracefully(monkeypatch):
+    pool, input_queue, output_queue, process = make_stubbed_pool(monkeypatch)
+
+    assert list(pool.semi_ordered_map(["input"])) == [(0, "result")]
+
+    process.join.assert_called_once_with()
+    process.terminate.assert_not_called()
+    input_queue.join_thread.assert_called_once_with()
+    output_queue.join_thread.assert_called_once_with()


### PR DESCRIPTION
### Summary

- detect when a parallel result iterator exits before it is fully consumed
- use the bounded emergency shutdown path instead of joining workers that may still be blocked on the input queue
- preserve graceful joins for fully consumed iterators
- cover early close, input failure, and normal exhaustion with regression tests

### Testing

- `pytest -q tests/test_parallel_processor.py tests/test_common.py` (4 passed)
- real multiprocessing reproduction: partial `ordered_map()` close returns and leaves zero tracked processes
- `ruff check fastembed/parallel_processor.py tests/test_parallel_processor.py`
- `ruff format --check fastembed/parallel_processor.py tests/test_parallel_processor.py`
- `pytest --collect-only -q` (92 tests collected)

### All Submissions

- [x] Followed the contributing guidelines
- [x] Checked for other open pull requests covering the same change

Closes #669