### PR TITLE
fix: block tar path traversal in decompress_to_cache

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -281,6 +281,16 @@ class ModelManagement(Generic[T]):
 
         return result
 
+    @staticmethod
+    def _safe_extractall(tar: tarfile.TarFile, cache_dir: str) -> None:
+        # Manual traversal guard for interpreters without the 'data' extraction filter.
+        base = os.path.realpath(cache_dir)
+        for member in tar.getmembers():
+            target = os.path.realpath(os.path.join(cache_dir, member.name))
+            if os.path.commonpath([base, target]) != base:
+                raise ValueError(f"Blocked path traversal in tar member: {member.name!r}")
+        tar.extractall(path=cache_dir)
+
     @classmethod
     def decompress_to_cache(cls, targz_path: str, cache_dir: str) -> str:
         """
@@ -304,10 +314,12 @@ class ModelManagement(Generic[T]):
         try:
             # Open the tar.gz file
             with tarfile.open(targz_path, "r:gz") as tar:
-                # Extract all files into the cache directory
-                tar.extractall(
-                    path=cache_dir,
-                )
+                # Guard against path traversal (CVE-2007-4559): the 'data' filter
+                # rejects members escaping cache_dir; fall back for pre-3.12 runtimes.
+                try:
+                    tar.extractall(path=cache_dir, filter="data")
+                except TypeError:
+                    cls._safe_extractall(tar, cache_dir)
         except tarfile.TarError as e:
             # If any error occurs while opening or extracting the tar.gz file,
             # delete the cache directory (if it was created in this function)

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,9 @@
+import io
+import os
+import tarfile
+
+import pytest
+
 from fastembed import (
     TextEmbedding,
     SparseTextEmbedding,
@@ -5,6 +11,7 @@ from fastembed import (
     LateInteractionMultimodalEmbedding,
     LateInteractionTextEmbedding,
 )
+from fastembed.common.model_management import ModelManagement
 
 
 def test_text_list_supported_models():
@@ -28,3 +35,34 @@ def test_text_list_supported_models():
         assert "model_file" in description and description["model_file"]
         assert "sources" in description and description["sources"]
         assert "hf" in description["sources"] or "url" in description["sources"]
+
+
+def test_decompress_to_cache_blocks_path_traversal(tmp_path):
+    targz_path = tmp_path / "evil.tar.gz"
+    escape_target = tmp_path / "escaped.txt"
+    with tarfile.open(targz_path, "w:gz") as tar:
+        payload = b"PWNED"
+        info = tarfile.TarInfo(name=f"../{escape_target.name}")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    with pytest.raises(ValueError):
+        ModelManagement.decompress_to_cache(str(targz_path), str(cache_dir))
+    assert not escape_target.exists()
+
+
+def test_decompress_to_cache_extracts_safe_archive(tmp_path):
+    targz_path = tmp_path / "safe.tar.gz"
+    with tarfile.open(targz_path, "w:gz") as tar:
+        payload = b"model bytes"
+        info = tarfile.TarInfo(name="model/config.json")
+        info.size = len(payload)
+        tar.addfile(info, io.BytesIO(payload))
+
+    cache_dir = tmp_path / "cache"
+    cache_dir.mkdir()
+    ModelManagement.decompress_to_cache(str(targz_path), str(cache_dir))
+    assert (cache_dir / "model" / "config.json").read_bytes() == b"model bytes"
+    assert os.path.isdir(cache_dir)


### PR DESCRIPTION
Fixes #626. `decompress_to_cache` called `tarfile.extractall()` with no member sanitization, so a tar archive with a `../` member could write files anywhere the process can write — outside `cache_dir`. This is reachable through `add_custom_model()` pointing at an attacker-controlled URL, or a compromised HF/GCS source.

Switched extraction to the `data` filter (PEP 706), which rejects members that escape the destination. For interpreters that predate the filter argument, there's a small fallback that resolves each member path and refuses anything landing outside `cache_dir`. A malicious member now raises instead of extracting; normal nested paths extract as before.

Added a test that a `../` member is blocked and never written, plus one that a well-formed archive still extracts. On unpatched code the traversal test fails (the file lands outside the cache). Pinned ruff and ruff-format are clean.
