### PR TITLE
fix: skip the bm25 mock model_file in the offline cache probe

### DIFF
--- a/fastembed/common/model_management.py
+++ b/fastembed/common/model_management.py
@@ -24,6 +24,10 @@ T = TypeVar("T", bound=BaseModelDescription)
 
 class ModelManagement(Generic[T]):
     METADATA_FILE = "files_metadata.json"
+    # Placeholder ``model_file`` for models that have no real ONNX weight file
+    # (e.g. ``Qdrant/bm25``); such a file is never present on disk and must not be
+    # required by the offline cache probe.
+    MOCK_MODEL_FILE = "mock.file"
 
     @classmethod
     def list_supported_models(cls) -> list[dict[str, Any]]:
@@ -421,9 +425,10 @@ class ModelManagement(Generic[T]):
                         **cache_kwargs,
                     )
                 )
-                if (resolved_path / model.model_file).exists() and all(
-                    (resolved_path / file).exists() for file in extra_patterns
-                ):
+                required_files = [
+                    file for file in extra_patterns if file != cls.MOCK_MODEL_FILE
+                ]
+                if all((resolved_path / file).exists() for file in required_files):
                     return resolved_path
             except Exception:
                 pass

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from fastembed import (
     TextEmbedding,
     SparseTextEmbedding,
@@ -5,6 +7,8 @@ from fastembed import (
     LateInteractionMultimodalEmbedding,
     LateInteractionTextEmbedding,
 )
+from fastembed.common.model_management import ModelManagement
+from fastembed.sparse.bm25 import Bm25, supported_bm25_models
 
 
 def test_text_list_supported_models():
@@ -28,3 +32,48 @@ def test_text_list_supported_models():
         assert "model_file" in description and description["model_file"]
         assert "sources" in description and description["sources"]
         assert "hf" in description["sources"] or "url" in description["sources"]
+
+
+def test_bm25_resolves_offline_without_network_fetch(tmp_path, monkeypatch):
+    """A mock model (``Qdrant/bm25``) whose real required files are already cached
+    must short-circuit locally and never trigger a network fetch.
+
+    ``bm25`` uses ``model_file="mock.file"`` as a placeholder that never exists on
+    disk; its real required files are ``additional_files`` (the ``{lang}.txt``
+    stop-word lists). The offline cache probe must therefore ignore the mock file.
+    """
+    model = supported_bm25_models[0]
+    assert model.model_file == ModelManagement.MOCK_MODEL_FILE
+
+    hf_repo = model.sources.hf
+    snapshot_dir = tmp_path / f"models--{hf_repo.replace('/', '--')}"
+    snapshot_dir.mkdir(parents=True)
+    # Seed the cache with the *real* required files only (NOT the mock model_file).
+    for fname in model.additional_files:
+        (snapshot_dir / fname).write_text("stopword\n")
+
+    seen_local_files_only: list[bool] = []
+
+    def fake_download_files_from_huggingface(
+        hf_source_repo, cache_dir, extra_patterns, **kwargs
+    ):
+        local_files_only = bool(kwargs.get("local_files_only"))
+        seen_local_files_only.append(local_files_only)
+        if local_files_only:
+            # The offline probe: hand back the already-populated snapshot dir.
+            return str(snapshot_dir)
+        # Reaching the online branch means the probe wrongly failed and a real
+        # network fetch was attempted despite every required file being present.
+        raise AssertionError("network fetch attempted despite cached files")
+
+    monkeypatch.setattr(
+        ModelManagement,
+        "download_files_from_huggingface",
+        staticmethod(fake_download_files_from_huggingface),
+    )
+
+    result = Bm25.download_model(model, str(tmp_path), local_files_only=False)
+
+    assert Path(result) == snapshot_dir
+    # Only the offline probe ran; the online (network) branch was never reached.
+    assert seen_local_files_only == [True]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -85,9 +85,7 @@ def test_bm25_resolves_offline_without_network_fetch(tmp_path, monkeypatch):
 
     seen_local_files_only: list[bool] = []
 
-    def fake_download_files_from_huggingface(
-        hf_source_repo, cache_dir, extra_patterns, **kwargs
-    ):
+    def fake_download_files_from_huggingface(hf_source_repo, cache_dir, extra_patterns, **kwargs):
         local_files_only = bool(kwargs.get("local_files_only"))
         seen_local_files_only.append(local_files_only)
         if local_files_only:


### PR DESCRIPTION
## Summary
For the Qdrant/bm25 sparse model, a fully-cached install still triggers a live Hugging Face Hub fetch instead of resolving offline. This makes Bm25 unusable with HF_HUB_OFFLINE=1 / local_files_only=True and adds an avoidable network round-trip on every load even when all files are already on disk.

Fixes #675.

## The bug
Qdrant/bm25 is a mock model with no real ONNX weight file; it declares a placeholder model_file of "mock.file", and its real required assets are the per-language stop-word lists in additional_files. The offline cache probe in `ModelManagement.download_model` required the model_file to exist on disk, but "mock.file" is never downloaded, so the check always failed and a fully-cached bm25 fell through to the live network fetch.

## The fix
Add a `MOCK_MODEL_FILE` constant on `ModelManagement` and filter it out of the required-files set before the existence check. For any real model, model_file is a genuine weight file that is not the mock placeholder, so it stays required and behavior is unchanged.

## Tests
A regression test seeds the cache with only the real additional_files, monkeypatches the Hub download, and asserts the resolved path is the cached snapshot and the network branch was never reached. Placed in tests/test_common.py to avoid colliding with open PR #642, which adds a new tests/test_model_management.py.

## Caveat
Verified against the real download_model control flow with a faked Hub call, not a live end-to-end download.
