### PR TITLE
Handle model_max_length / max_length = 0 in tokenizer config (fixes #685)

### DIFF
--- a/fastembed/common/preprocessor_utils.py
+++ b/fastembed/common/preprocessor_utils.py
@@ -36,15 +36,21 @@ def load_tokenizer(model_dir: Path) -> tuple[Tokenizer, dict[str, int]]:
 
     with open(str(tokenizer_config_path)) as tokenizer_config_file:
         tokenizer_config = json.load(tokenizer_config_file)
-        assert "model_max_length" in tokenizer_config or "max_length" in tokenizer_config, (
-            "Models without model_max_length or max_length are not supported."
+        # HuggingFace tokenizer configs may set `model_max_length` or `max_length`
+        # to 0 (or omit them entirely) — both mean "no cap". Truthiness handles
+        # missing, None, and 0 uniformly so we don't disable truncation on
+        # unusual-but-valid tokenizer configs.
+        model_max_length = tokenizer_config.get("model_max_length")
+        max_length = tokenizer_config.get("max_length")
+        assert model_max_length or max_length, (
+            "Models without a non-zero model_max_length or max_length are not supported."
         )
-        if "model_max_length" not in tokenizer_config:
-            max_context = tokenizer_config["max_length"]
-        elif "max_length" not in tokenizer_config:
-            max_context = tokenizer_config["model_max_length"]
+        if not model_max_length:
+            max_context = max_length
+        elif not max_length:
+            max_context = model_max_length
         else:
-            max_context = min(tokenizer_config["model_max_length"], tokenizer_config["max_length"])
+            max_context = min(model_max_length, max_length)
 
     tokens_map = load_special_tokens(model_dir)
 

--- a/tests/test_preprocessor_utils.py
+++ b/tests/test_preprocessor_utils.py
@@ -1,0 +1,117 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from fastembed.common.preprocessor_utils import load_tokenizer
+
+
+def _write_tokenizer_dir(
+    tmp_path: Path,
+    *,
+    model_max_length,
+    max_length,
+    include_model_max_length: bool = True,
+    include_max_length: bool = True,
+) -> Path:
+    """
+    Write the three files `load_tokenizer` requires, using a minimal but
+    Tokenizers-loadable tokenizer.json.
+    """
+    (tmp_path / "config.json").write_text(json.dumps({"pad_token_id": 0}))
+
+    tokenizer_config: dict = {"pad_token": "[PAD]"}
+    if include_model_max_length:
+        tokenizer_config["model_max_length"] = model_max_length
+    if include_max_length:
+        tokenizer_config["max_length"] = max_length
+    (tmp_path / "tokenizer_config.json").write_text(json.dumps(tokenizer_config))
+
+    (tmp_path / "special_tokens_map.json").write_text(json.dumps({"pad_token": "[PAD]"}))
+
+    # Minimal WordLevel tokenizer that the `tokenizers` crate accepts.
+    tokenizer_json = {
+        "version": "1.0",
+        "truncation": None,
+        "padding": None,
+        "added_tokens": [
+            {
+                "id": 0,
+                "content": "[PAD]",
+                "single_word": False,
+                "lstrip": False,
+                "rstrip": False,
+                "normalized": False,
+                "special": True,
+            }
+        ],
+        "normalizer": None,
+        "pre_tokenizer": {"type": "Whitespace"},
+        "post_processor": None,
+        "decoder": None,
+        "model": {"type": "WordLevel", "vocab": {"[PAD]": 0, "hello": 1}, "unk_token": "[PAD]"},
+    }
+    (tmp_path / "tokenizer.json").write_text(json.dumps(tokenizer_json))
+
+    return tmp_path
+
+
+class TestLoadTokenizerMaxLength:
+    """Regression tests for https://github.com/qdrant/fastembed/issues/685"""
+
+    def test_zero_max_length_falls_back_to_model_max_length(self, tmp_path: Path) -> None:
+        # `max_length=0` in a HuggingFace tokenizer config means "no cap" and
+        # must not disable truncation. Prior behavior picked the 0 in the
+        # `min()`, then crashed on any input longer than 0 tokens.
+        _write_tokenizer_dir(
+            tmp_path, model_max_length=512, max_length=0
+        )
+        tokenizer, _ = load_tokenizer(tmp_path)
+        # `enable_truncation` should have been called with the non-zero cap.
+        assert tokenizer.truncation is not None
+        assert tokenizer.truncation["max_length"] == 512
+
+    def test_zero_model_max_length_falls_back_to_max_length(self, tmp_path: Path) -> None:
+        _write_tokenizer_dir(
+            tmp_path, model_max_length=0, max_length=256
+        )
+        tokenizer, _ = load_tokenizer(tmp_path)
+        assert tokenizer.truncation is not None
+        assert tokenizer.truncation["max_length"] == 256
+
+    def test_both_present_and_non_zero_takes_min(self, tmp_path: Path) -> None:
+        _write_tokenizer_dir(
+            tmp_path, model_max_length=512, max_length=256
+        )
+        tokenizer, _ = load_tokenizer(tmp_path)
+        assert tokenizer.truncation is not None
+        assert tokenizer.truncation["max_length"] == 256
+
+    def test_only_max_length_present(self, tmp_path: Path) -> None:
+        _write_tokenizer_dir(
+            tmp_path,
+            model_max_length=None,
+            max_length=128,
+            include_model_max_length=False,
+        )
+        tokenizer, _ = load_tokenizer(tmp_path)
+        assert tokenizer.truncation is not None
+        assert tokenizer.truncation["max_length"] == 128
+
+    def test_only_model_max_length_present(self, tmp_path: Path) -> None:
+        _write_tokenizer_dir(
+            tmp_path,
+            model_max_length=128,
+            max_length=None,
+            include_max_length=False,
+        )
+        tokenizer, _ = load_tokenizer(tmp_path)
+        assert tokenizer.truncation is not None
+        assert tokenizer.truncation["max_length"] == 128
+
+    def test_both_zero_raises(self, tmp_path: Path) -> None:
+        _write_tokenizer_dir(
+            tmp_path, model_max_length=0, max_length=0
+        )
+        with pytest.raises(AssertionError):
+            load_tokenizer(tmp_path)


### PR DESCRIPTION
Fixes #685.

## What changed

HuggingFace tokenizer configs may set `model_max_length` or `max_length` to `0` — used e.g. when a tokenizer stores its padding token inline in `tokenizer.json` without an external file. The prior key-existence check in `load_tokenizer` picked the `0` in the `min()`, then `tokenizer.enable_truncation(max_length=0)` silently disabled truncation, and any input past the underlying model's context window crashed downstream.

Switched to truthiness checks so `0` falls back to the other key (or to `AssertionError` when both are 0/missing).

## Fix

```diff
     with open(str(tokenizer_config_path)) as tokenizer_config_file:
         tokenizer_config = json.load(tokenizer_config_file)
-        assert "model_max_length" in tokenizer_config or "max_length" in tokenizer_config, (
-            "Models without model_max_length or max_length are not supported."
+        model_max_length = tokenizer_config.get("model_max_length")
+        max_length = tokenizer_config.get("max_length")
+        assert model_max_length or max_length, (
+            "Models without a non-zero model_max_length or max_length are not supported."
         )
-        if "model_max_length" not in tokenizer_config:
-            max_context = tokenizer_config["max_length"]
-        elif "max_length" not in tokenizer_config:
-            max_context = tokenizer_config["model_max_length"]
+        if not model_max_length:
+            max_context = max_length
+        elif not max_length:
+            max_context = model_max_length
         else:
-            max_context = min(tokenizer_config["model_max_length"], tokenizer_config["max_length"])
+            max_context = min(model_max_length, max_length)
```

Handles both cases the reporter flagged (either key present as `0`) as well as the missing-key cases the original code already covered.

## Tests

Added `tests/test_preprocessor_utils.py` — 6 tests covering:

- `model_max_length=0` falls back to `max_length`
- `max_length=0` falls back to `model_max_length`
- both non-zero → `min()` still wins
- only one key present in the config (works as before)
- both zero → `AssertionError` (still fails loud)

All 6 pass locally against `fastembed@0.8.0`.