### PR TITLE
new: add minish models

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -183,25 +183,34 @@ supported_onnx_models: list[DenseModelDescription] = [
     DenseModelDescription(
         model="minishlab/potion-base-8m",
         dim=256,
-        description=("Text embeddings, Extremely fast, Unimodal (text), English, 2024 year."),
+        description=(
+            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
+            "Prefixes for queries/documents: not necessary, 2024 year."
+        ),
         license="mit",
         size_in_GB=0.030,
         sources=ModelSource(hf="minishlab/potion-base-8m-onnx"),
         model_file="model.onnx",
     ),
     DenseModelDescription(
-        model="minishlab/potion-retrieval-32m",
+        model="minishlab/potion-retrieval-32M",
         dim=512,
-        description=("Text embeddings, Extremely fast, Unimodal (text), English, 2025 year."),
+        description=(
+            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
+            "Prefixes for queries/documents: not necessary, 2025 year."
+        ),
         license="mit",
         size_in_GB=0.129,
         sources=ModelSource(hf="minishlab/potion-retrieval-32m-onnx"),
         model_file="model.onnx",
     ),
     DenseModelDescription(
-        model="minishlab/potion-multilingual-128m",
+        model="minishlab/potion-multilingual-128M",
         dim=256,
-        description=("Text embeddings, Extremely fast, Unimodal (text), Multilingual, 2025 year."),
+        description=(
+            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
+            "Prefixes for queries/documents: not necessary, 2025 year."
+        ),
         license="mit",
         size_in_GB=0.512,
         sources=ModelSource(hf="minishlab/potion-multilingual-128m-onnx"),

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -208,7 +208,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         model="minishlab/potion-multilingual-128M",
         dim=256,
         description=(
-            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
+            "Text embeddings, Unimodal (text), Multilingual, 512 input tokens truncation, "
             "Prefixes for queries/documents: not necessary, 2025 year."
         ),
         license="mit",

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -1,11 +1,11 @@
 from typing import Any, Iterable, Sequence, Type
 
-from fastembed.common.types import NumpyArray, OnnxProvider, Device
+from fastembed.common.model_description import DenseModelDescription, ModelSource
 from fastembed.common.onnx_model import OnnxOutputContext
+from fastembed.common.types import Device, NumpyArray, OnnxProvider
 from fastembed.common.utils import define_cache_dir, normalize
 from fastembed.text.onnx_text_model import OnnxTextModel, TextEmbeddingWorker
 from fastembed.text.text_embedding_base import TextEmbeddingBase
-from fastembed.common.model_description import DenseModelDescription, ModelSource
 
 supported_onnx_models: list[DenseModelDescription] = [
     DenseModelDescription(
@@ -179,6 +179,33 @@ supported_onnx_models: list[DenseModelDescription] = [
         size_in_GB=0.55,
         sources=ModelSource(hf="jinaai/jina-clip-v1"),
         model_file="onnx/text_model.onnx",
+    ),
+    DenseModelDescription(
+        model="minishlab/potion-base-8m",
+        dim=256,
+        description=("Text embeddings, Unimodal (text), English, 2024 year."),
+        license="mit",
+        size_in_GB=0.030,
+        sources=ModelSource(hf="minishlab/potion-base-8m-onnx"),
+        model_file="model.onnx",
+    ),
+    DenseModelDescription(
+        model="minishlab/potion-retrieval-32m",
+        dim=512,
+        description=("Text embeddings, Unimodal (text), English, 2025 year."),
+        license="mit",
+        size_in_GB=0.129,
+        sources=ModelSource(hf="minishlab/potion-retrieval-32m-onnx"),
+        model_file="model.onnx",
+    ),
+    DenseModelDescription(
+        model="minishlab/potion-multilingual-128m",
+        dim=256,
+        description=("Text embeddings, Unimodal (text), Multilingual, 2025 year."),
+        license="mit",
+        size_in_GB=0.512,
+        sources=ModelSource(hf="minishlab/potion-multilingual-128m-onnx"),
+        model_file="model.onnx",
     ),
 ]
 

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -183,7 +183,7 @@ supported_onnx_models: list[DenseModelDescription] = [
     DenseModelDescription(
         model="minishlab/potion-base-8m",
         dim=256,
-        description=("Text embeddings, Unimodal (text), English, 2024 year."),
+        description=("Text embeddings, Extremely fast, Unimodal (text), English, 2024 year."),
         license="mit",
         size_in_GB=0.030,
         sources=ModelSource(hf="minishlab/potion-base-8m-onnx"),
@@ -192,7 +192,7 @@ supported_onnx_models: list[DenseModelDescription] = [
     DenseModelDescription(
         model="minishlab/potion-retrieval-32m",
         dim=512,
-        description=("Text embeddings, Unimodal (text), English, 2025 year."),
+        description=("Text embeddings, Extremely fast, Unimodal (text), English, 2025 year."),
         license="mit",
         size_in_GB=0.129,
         sources=ModelSource(hf="minishlab/potion-retrieval-32m-onnx"),
@@ -201,7 +201,7 @@ supported_onnx_models: list[DenseModelDescription] = [
     DenseModelDescription(
         model="minishlab/potion-multilingual-128m",
         dim=256,
-        description=("Text embeddings, Unimodal (text), Multilingual, 2025 year."),
+        description=("Text embeddings, Extremely fast, Unimodal (text), Multilingual, 2025 year."),
         license="mit",
         size_in_GB=0.512,
         sources=ModelSource(hf="minishlab/potion-multilingual-128m-onnx"),

--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -181,7 +181,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         model_file="onnx/text_model.onnx",
     ),
     DenseModelDescription(
-        model="minishlab/potion-base-8m",
+        model="minishlab/potion-base-8M",
         dim=256,
         description=(
             "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -82,6 +82,15 @@ CANONICAL_VECTOR_VALUES = {
     "google/siglip2-base-patch16-224": np.array(
         [-0.01181389, 0.00737596, 0.01118064, 0.0103095, 0.3451049]
     ),
+    "minishlab/potion-base-8m": np.array(
+        [-0.03432461, -0.08020256, -0.14396408, 0.08480079, 0.01958815]
+    ),
+    "minishlab/potion-retrieval-32m": np.array(
+        [0.019733, -0.01530093, -0.08678473, 0.0229059, 0.04700558]
+    ),
+    "minishlab/potion-multilingual-128m": np.array(
+        [0.02366836, 0.02973341, 0.05140258, -0.00745248, -0.06740689]
+    ),
 }
 
 QWEN3_INSTRUCT_PREFIX = (

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -82,13 +82,13 @@ CANONICAL_VECTOR_VALUES = {
     "google/siglip2-base-patch16-224": np.array(
         [-0.01181389, 0.00737596, 0.01118064, 0.0103095, 0.3451049]
     ),
-    "minishlab/potion-base-8m": np.array(
+    "minishlab/potion-base-8M": np.array(
         [-0.03432461, -0.08020256, -0.14396408, 0.08480079, 0.01958815]
     ),
-    "minishlab/potion-retrieval-32m": np.array(
+    "minishlab/potion-retrieval-32M": np.array(
         [0.019733, -0.01530093, -0.08678473, 0.0229059, 0.04700558]
     ),
-    "minishlab/potion-multilingual-128m": np.array(
+    "minishlab/potion-multilingual-128M": np.array(
         [0.02366836, 0.02973341, 0.05140258, -0.00745248, -0.06740689]
     ),
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?

### New models submission:

* [x] Have you added an explanation of why it's important to include this model?
* [x] Have you added tests for the new model? Were canonical values for tests computed via the original model?
* [x] Have you added the code snippet for how canonical values were computed?
* [x] Have you successfully ran tests with your changes locally?


This PR adds support for three minishlab models:

* potion-base-8m
* potion-retrieval-32m
* potion-multilingual-128m

I put these in separate onnx exports, so it doesn't clutter up our main repositories. As discussed, these models are directly loaded as text embedders. They don't have post-processors, so special tokens do not get added. The test script below shows all lines are close to the original model counterparts. When run on this branch, it just works out of the box.

```python
import numpy as np
from model2vec import StaticModel

from fastembed import TextEmbedding

models = [
    "minishlab/potion-base-8m",
    "minishlab/potion-retrieval-32m",
    "minishlab/potion-multilingual-128m",
]
lines = """Link: Don't worry, I'll handle this! (Link hits branch and Zelda falls)
Link: Ha ha ha. (tree branch grabs Link)
Zelda: Ha ha ha. I suppose I better get you loose. I guess.
Link: Hurry up, I'm getting squashed! (Zelda frees him with an arrow, then Link and Zelda fall down a trap)
Spryte: Link, Zelda, wait!
(at Ganon's lair)
Ganon: There, the two Triforces side by side. Nothing stands in my way now! (hears Link and Zelda fall) Hmm...we have visitors.
Zelda: Some shortcut. (Zelda and Link are trapped in a large glass container)
Ganon: Well, what have we here?
Link: Ganon! (shoots a sword beam but bounces around the glass container)
Ganon: Very good, Link. Do you know any other tricks?
Link: Lemme out of here and we'll see who laughs last.
Ganon: Strong enough to hold even the most impetuous hero. Too bad you won't be around long enough to appreciate its finest qualities. (whistles and calls a Gohma from one of the cells) Dinner time!
Link: Stay down, I'll handle this.
Zelda: Where have I heard that before...
(Gohma tries to attack the heroes but the glass container is in the way)
Ganon: No, Gohma, no! Reach down from the top! (Gohma reaches down from the top and grabs Link's sword)
Link: Let go, or I'll make crab cakes out of you!
Spryte: Link's in trouble! Maybe my magic will do something! (shoots a beam that causes Gohma to let Link out of container)
(Link shoots various sword beams at Ganon) """.splitlines()


for name in models:
    static = StaticModel.from_pretrained(name)
    fast = TextEmbedding(model_name=name)

    for line in lines:
        x = static.encode(line)
        y = list(fast.embed(line))[0]
        assert np.allclose(x, y)

    x = static.encode(lines)
    y = list(fast.embed(lines))
```

It tests both batch and single lines. 

I also added the canonical values to the tests.