### PR TITLE
feat: add intfloat/multilingual-e5-small support

### DIFF
--- a/fastembed/text/pooled_embedding.py
+++ b/fastembed/text/pooled_embedding.py
@@ -71,6 +71,20 @@ supported_pooled_models: list[DenseModelDescription] = [
         model_file="onnx/model.onnx",
     ),
     DenseModelDescription(
+        model="intfloat/multilingual-e5-small",
+        dim=384,
+        description=(
+            "Text embeddings, Unimodal (text), Multilingual (~100 languages), 512 input tokens truncation, "
+            "Prefixes for queries/documents: necessary, 2024 year."
+        ),
+        license="mit",
+        size_in_GB=0.47,
+        sources=ModelSource(
+            hf="intfloat/multilingual-e5-small",
+        ),
+        model_file="onnx/model.onnx",
+    ),
+    DenseModelDescription(
         model="intfloat/multilingual-e5-large",
         dim=1024,
         description=(

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -37,6 +37,7 @@ CANONICAL_VECTOR_VALUES = {
     "sentence-transformers/paraphrase-multilingual-MiniLM-L12-v2": np.array(
         [0.0361, 0.1862, 0.2776, 0.2461, -0.1904]
     ),
+    "intfloat/multilingual-e5-small": np.array([0.1460, 0.1443, -0.1638, -0.3137, 0.3968]),
     "intfloat/multilingual-e5-large": np.array([0.4544, -0.0968, 0.1054, -1.3753, 0.1500]),
     "sentence-transformers/paraphrase-multilingual-mpnet-base-v2": np.array(
         [0.0047, 0.1334, -0.0102, 0.0714, 0.1930]


### PR DESCRIPTION
## Summary

Fixes #123.

Add native support for `intfloat/multilingual-e5-small` to FastEmbed's pooled text embedding models.

## Changes

- Register `intfloat/multilingual-e5-small`
- Use the model's ONNX export from Hugging Face
- Add model metadata for dimension, license, size, and supported languages
- Add canonical embedding values for regression testing

The model is also usable through `TextEmbedding.add_custom_model`; native registration makes it discoverable through the standard supported-model list.

## Tests

- Model downloaded and loaded successfully
- Embedding shape verified as `(384,)`
- Canonical embedding values verified within the existing tolerance
- `python -m compileall -q fastembed tests/test_text_onnx_embeddings.py`
- `git diff --check`