### PR TITLE
fix: pass (width, height) to Pillow in the Resize transform

### DIFF
--- a/fastembed/image/transform/functional.py
+++ b/fastembed/image/transform/functional.py
@@ -98,7 +98,12 @@ def resize(
     resample: int | Image.Resampling = Image.Resampling.BILINEAR,
 ) -> Image.Image:
     if isinstance(size, tuple):
-        return image.resize(size, resample)
+        # fastembed keeps sizes as (height, width) — `Transform.from_config` builds
+        # the tuple as (size["height"], size["width"]) — while Pillow's resize takes
+        # (width, height). The two agree for square sizes, so this only shows up on
+        # a non-square image processor configuration.
+        height, width = size
+        return image.resize((width, height), resample)
 
     height, width = image.height, image.width
     short, long = (width, height) if width <= height else (height, width)

--- a/tests/test_image_transform.py
+++ b/tests/test_image_transform.py
@@ -1,0 +1,45 @@
+from PIL import Image
+
+from fastembed.image.transform.functional import resize
+from fastembed.image.transform.operators import Resize
+
+
+def test_resize_tuple_converts_from_height_width_to_pillow_order():
+    """A ``(height, width)`` size must reach Pillow as ``(width, height)``.
+
+    ``Transform.from_config`` builds the tuple as ``(size["height"], size["width"])``,
+    so every tuple reaching ``resize`` is in fastembed's height-first order, while
+    ``PIL.Image.resize`` takes width first. The two agree for square sizes, which is
+    why this went unnoticed.
+    """
+    image = Image.new("RGB", (300, 300))
+
+    resized = resize(image, size=(100, 200))
+
+    assert resized.size == (200, 100)  # PIL reports (width, height)
+
+
+def test_resize_operator_produces_requested_height_and_width():
+    image = Image.new("RGB", (300, 300))
+
+    resized = Resize(size=(100, 200))([image])[0]
+
+    width, height = resized.size
+    assert (height, width) == (100, 200)
+
+
+def test_resize_square_tuple_is_unchanged():
+    """The square case behaved correctly before and must keep doing so."""
+    image = Image.new("RGB", (300, 200))
+
+    assert resize(image, size=(224, 224)).size == (224, 224)
+
+
+def test_resize_int_keeps_shortest_edge_behaviour():
+    """The int branch already emitted Pillow order; it must not be disturbed."""
+    landscape = Image.new("RGB", (400, 200))
+    portrait = Image.new("RGB", (200, 400))
+
+    # size sets the shortest edge, and the aspect ratio is preserved.
+    assert resize(landscape, size=100).size == (200, 100)
+    assert resize(portrait, size=100).size == (100, 200)


### PR DESCRIPTION
Fixes #649.

### What was wrong

`resize()` passed a tuple size straight through to `PIL.Image.resize()`:

```python
if isinstance(size, tuple):
    return image.resize(size, resample)
```

fastembed keeps sizes as `(height, width)` — `Transform.from_config` builds the tuple as `(size["height"], size["width"])` — while Pillow's `resize` takes `(width, height)`. For a non-square image processor configuration the output comes back transposed.

### Reproduction

On `main`, Windows 11, Python 3.13:

```python
from PIL import Image
from fastembed.image.transform.operators import Resize

out = Resize(size=(100, 200))([Image.new("RGB", (300, 300))])[0]
print(out.size)   # (100, 200)  -- Pillow reports (width, height)
                  # expected (200, 100), i.e. height 100 and width 200
```

Square sizes are unaffected, which is why this has gone unnoticed.

### Why the conversion belongs in `resize()`

`Resize.__call__` is the only caller of this function, and its `size` always originates from `Transform.from_config` in fastembed's height-first order — so there is no caller that would be broken by converting here.

Two things deliberately left alone:

- the `int` branch of `resize()` already emits Pillow order (`new_size` is assembled as width-then-height in both aspect-ratio cases)
- `resize_ndarray()` is a different function, and its two callers in `operators.py` already pass `(new_width, new_height)` with an explicit `# PIL expects (width, height)` comment

### Tests

Four cases in a new `tests/test_image_transform.py`. Two cover the bug and two are controls, so the suite cannot pass by simply transposing everything:

| Test | Purpose |
|---|---|
| `test_resize_tuple_converts_from_height_width_to_pillow_order` | the functional bug — fails on `main` |
| `test_resize_operator_produces_requested_height_and_width` | the same through `Resize`, as reported — fails on `main` |
| `test_resize_square_tuple_is_unchanged` | **control** — the square path must keep working |
| `test_resize_int_keeps_shortest_edge_behaviour` | **control** — the untouched `int` branch, both orientations |

Verified the two bug tests fail before the change and all four pass after.

### Checks run locally

- `pytest tests/test_image_transform.py` — 4 passed
- `pytest tests/` — **80 passed, 3 failed, 13 skipped** (19h38m; the suite downloads ONNX weights for every supported model). None of the three failures is attributable to this change:
  - `test_embedding[BAAI/bge-small-en-v1.5]` — a canonical-vector mismatch on a **text** model, which this change cannot reach
  - `test_batch_embedding` — an HTTP error fetching a remote fixture
  - `test_embedding[Qdrant/clip-ViT-B-32-vision]` — a canonical-vector mismatch on `nomic-ai/nomic-embed-vision-v1.5-Q`, an int8-quantized model. The test itself notes canonical vectors are generated on linux/amd64 and that quantized ops diverge by platform; this ran on Windows.

  On that last one, since it is the only failure anywhere near this code path: **every image processor config in the supported-model set is square (`{height: 224, width: 224}`, `{448, 448}`) or uses `shortest_edge`/`longest_edge`, which do not take the tuple branch at all.** I verified directly that for `(224, 224)` and `(448, 448)` the old and new code produce pixel-identical output, so this change is a provable no-op for every shipped model and only alters behaviour for the non-square case the issue reports.
- `mypy fastembed --disallow-incomplete-defs --disallow-untyped-defs --disable-error-code=import-untyped` — 5 errors, **all pre-existing** (`vocab_resolver.py`, `preprocessor_utils.py`, `colbert.py`); I confirmed the identical 5 on an unmodified `main`. Nothing in the changed file.
- `ruff check` on both changed files — clean; `ruff format --check` — already formatted

### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Does your submission pass the existing tests? — see above: 80 passed, and the 3 failures are pre-existing/environmental, none reachable from this change
* [x] Have you added tests for your feature?
* [ ] `pre-commit` — not installed locally; ran `ruff check` and `ruff format --check` directly instead

---

*Authored by Claude (an AI coding agent) on the account owner's machine and with their authorization; it was opened while they were away, and they have since reviewed the diff and confirmed it. The reproduction, the failing-test-first sequence and every check above were genuinely executed here rather than asserted. Flagging the AI authorship plainly rather than leaving it to be inferred — happy to take any correction in review.*
