### PR TITLE
fix: look up custom model postprocessing by resolved name

### DIFF
--- a/fastembed/text/custom_text_embedding.py
+++ b/fastembed/text/custom_text_embedding.py
@@ -50,8 +50,12 @@ class CustomTextEmbedding(OnnxTextEmbedding):
             specific_model_path=specific_model_path,
             **kwargs,
         )
-        self._pooling = self.POSTPROCESSING_MAPPING[model_name].pooling
-        self._normalization = self.POSTPROCESSING_MAPPING[model_name].normalization
+        # POSTPROCESSING_MAPPING is keyed by the registered name, while model
+        # lookup is case-insensitive, so the caller's spelling need not match.
+        # Use the resolved description's name rather than the argument.
+        postprocessing = self.POSTPROCESSING_MAPPING[self.model_description.model]
+        self._pooling = postprocessing.pooling
+        self._normalization = postprocessing.normalization
 
     @classmethod
     def _list_supported_models(cls) -> list[DenseModelDescription]:

--- a/tests/test_custom_models.py
+++ b/tests/test_custom_models.py
@@ -21,9 +21,11 @@ from tests.utils import delete_model_cache
 @pytest.fixture(autouse=True)
 def restore_custom_models_fixture():
     CustomTextEmbedding.SUPPORTED_MODELS = []
+    CustomTextEmbedding.POSTPROCESSING_MAPPING = {}
     CustomTextCrossEncoder.SUPPORTED_MODELS = []
     yield
     CustomTextEmbedding.SUPPORTED_MODELS = []
+    CustomTextEmbedding.POSTPROCESSING_MAPPING = {}
     CustomTextCrossEncoder.SUPPORTED_MODELS = []
 
 
@@ -250,3 +252,41 @@ def test_do_not_add_existing_cross_encoder():
         )
 
     CustomTextCrossEncoder.SUPPORTED_MODELS.clear()
+
+
+def test_custom_model_postprocessing_lookup_is_case_insensitive():
+    """A custom model may be registered and instantiated with different casing.
+
+    `TextEmbedding` resolves model names case-insensitively, so
+    `CustomTextEmbedding` has to look its postprocessing config up by the resolved
+    canonical name rather than by whatever string the caller happened to type.
+    """
+    TextEmbedding.add_custom_model(
+        "Org/Model",
+        pooling=PoolingType.MEAN,
+        normalization=True,
+        sources=ModelSource(hf="intfloat/multilingual-e5-small"),
+        dim=384,
+    )
+
+    model = TextEmbedding("org/model", lazy_load=True).model
+
+    assert model.model_description.model == "Org/Model"
+    assert model._pooling == PoolingType.MEAN
+    assert model._normalization is True
+
+
+def test_custom_model_postprocessing_lookup_with_matching_case_still_works():
+    """Control: the exact-casing path worked before and must keep working."""
+    TextEmbedding.add_custom_model(
+        "Org/Model",
+        pooling=PoolingType.CLS,
+        normalization=False,
+        sources=ModelSource(hf="intfloat/multilingual-e5-small"),
+        dim=384,
+    )
+
+    model = TextEmbedding("Org/Model", lazy_load=True).model
+
+    assert model._pooling == PoolingType.CLS
+    assert model._normalization is False


### PR DESCRIPTION
Fixes #650.

### What was wrong

`CustomTextEmbedding.__init__` looked up its postprocessing config with the `model_name` argument:

```python
self._pooling = self.POSTPROCESSING_MAPPING[model_name].pooling
self._normalization = self.POSTPROCESSING_MAPPING[model_name].normalization
```

But `POSTPROCESSING_MAPPING` is keyed by `model_description.model` — the name the model was *registered* under (`add_model`) — while model lookup is case-insensitive (`_get_model_description` compares `model_name.lower() == model.model.lower()`). So the caller's spelling need not match the registered key.

### Reproduction

On `main`:

```python
from fastembed.common.model_description import PoolingType, ModelSource
from fastembed.text.text_embedding import TextEmbedding

TextEmbedding.add_custom_model(
    "Org/Model", pooling=PoolingType.MEAN, normalization=True,
    sources=ModelSource(hf="intfloat/multilingual-e5-small"), dim=384,
)
TextEmbedding("org/model", lazy_load=True)
```

```text
  File "fastembed/text/custom_text_embedding.py", line 53, in __init__
    self._pooling = self.POSTPROCESSING_MAPPING[model_name].pooling
KeyError: 'org/model'
```

Resolution itself is fine — `TextEmbedding._get_model_description("org/model").model` correctly returns `"Org/Model"`. Only the mapping lookup uses the raw argument.

### The change

`self.model_description` is already set by the base class from that same case-insensitive matcher, so `.model` is the canonical registered name. The lookup now uses it, and reads the entry once instead of twice.

### Tests

Two cases in `tests/test_custom_models.py`:

| Test | Purpose |
|---|---|
| `test_custom_model_postprocessing_lookup_is_case_insensitive` | register `Org/Model`, instantiate `org/model` — fails on `main` with the `KeyError` above |
| `test_custom_model_postprocessing_lookup_with_matching_case_still_works` | **control** — exact casing worked before and must keep working, including a different pooling/normalization pair so the assertion is not vacuous |

Both use `lazy_load=True`, so they exercise the constructor without downloading weights.

### One extra change, called out

The autouse `restore_custom_models_fixture` reset `SUPPORTED_MODELS` but not `POSTPROCESSING_MAPPING`, so a registration leaked into every later test in the file. Adding a test that registers a model made that visible, so the fixture now clears both. Happy to split it out if you would rather it landed separately.

### Checks run locally

Windows 11, Python 3.12:

- `pytest tests/test_custom_models.py` — **7 passed** (5 existing + 2 new)
- `mypy fastembed --disallow-incomplete-defs --disallow-untyped-defs --disable-error-code=import-untyped` — 5 errors, **all pre-existing** in `vocab_resolver.py`, `preprocessor_utils.py` and `colbert.py`; none in the changed file, and identical on an unmodified `main`
- `ruff check` on both changed files — 5 findings, **all pre-existing** (`UP035`/`I001` import style), byte-identical on an unmodified `main`; `ruff format --check` — already formatted

I did not run the full `pytest tests/` here: it downloads ONNX weights for every supported model and takes ~20 hours on this machine. This change touches only the custom-model constructor path, which the tests above cover directly.

### All Submissions

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
* [x] Have you added tests for your feature?
* [ ] `pre-commit` — not installed locally; ran `ruff check` and `ruff format --check` directly instead

---

*Authored by Claude (an AI coding agent) on the account owner's machine and with their authorization; they have reviewed the change and confirmed it. The reproduction, the failing-test-first sequence and every check above were genuinely executed here rather than asserted. Flagging the AI authorship plainly rather than leaving it to be inferred — happy to take any correction in review.*
