### PR TITLE
feat: Add ibm-granite/granite-embedding-small-english-r2 model

### DIFF
--- a/fastembed/text/builtin_sentence_embedding.py
+++ b/fastembed/text/builtin_sentence_embedding.py
@@ -9,6 +9,21 @@ from fastembed.common.model_description import DenseModelDescription, ModelSourc
 
 supported_builtin_sentence_embedding_models: list[DenseModelDescription] = [
     DenseModelDescription(
+        model="ibm-granite/granite-embedding-small-english-r2",
+        dim=384,
+        description=(
+            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
+            "Granite small english r2 model. 2024 year."
+        ),
+        license="apache-2.0",
+        size_in_GB=0.18,
+        sources=ModelSource(
+            hf="onnx-community/granite-embedding-small-english-r2-ONNX",
+        ),
+        model_file="onnx/model.onnx",
+        additional_files=["onnx/model.onnx_data"],
+    ),
+    DenseModelDescription(
         model="google/embeddinggemma-300m",
         dim=768,
         description=(

--- a/fastembed/text/builtin_sentence_embedding.py
+++ b/fastembed/text/builtin_sentence_embedding.py
@@ -12,8 +12,8 @@ supported_builtin_sentence_embedding_models: list[DenseModelDescription] = [
         model="ibm-granite/granite-embedding-small-english-r2",
         dim=384,
         description=(
-            "Text embeddings, Unimodal (text), English, 512 input tokens truncation, "
-            "Granite small english r2 model. 2024 year."
+            "Text embeddings, Unimodal (text), English, 8192 input tokens truncation, "
+            "Granite small english r2 model. 2025 year."
         ),
         license="apache-2.0",
         size_in_GB=0.18,

--- a/tests/test_text_onnx_embeddings.py
+++ b/tests/test_text_onnx_embeddings.py
@@ -31,6 +31,9 @@ CANONICAL_VECTOR_VALUES = {
     "BAAI/bge-large-en-v1.5-quantized": np.array(
         [0.03434538, 0.03316108, 0.02191251, -0.03713358, -0.01577825]
     ),
+    "ibm-granite/granite-embedding-small-english-r2": np.array(
+        [0.47021756, -0.08181943, -0.97021246, 0.10116885, -0.16487208]
+    ),
     "sentence-transformers/all-MiniLM-L6-v2": np.array(
         [-0.034478, 0.03102, 0.00673, 0.02611, -0.039362]
     ),


### PR DESCRIPTION
Resolves #701 

### Description
Adds support for the `ibm-granite/granite-embedding-small-english-r2` model using the ONNX Community exported weights. This is a highly requested, very lightweight embedding model that punches well above its weight class on the MTEB leaderboard.

**All Submissions:**
- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?

**New Feature Submissions:**
- [x] Does your submission pass the existing tests?
- [x] Have you added tests for your feature?
- [x] Have you installed `pre-commit` with `pip3 install pre-commit` and set up hooks with `pre-commit install`?

**New models submission:**
- [x] Have you added an explanation of why it's important to include this model?
- [x] Have you added tests for the new model? Were canonical values for tests computed via the original model?
- [x] Have you added the code snippet for how canonical values were computed?
- [x] Have you successfully ran tests with your changes locally?

<details>
<summary>Code snippet for canonical values</summary>

```python
from sentence_transformers import SentenceTransformer

model = SentenceTransformer("ibm-granite/granite-embedding-small-english-r2")
embeddings = model.encode(["hello world", "flag embedding"])

print(list(embeddings[0][:5]))
# Output: [0.47021756, -0.08181943, -0.97021246, 0.10116885, -0.16487208]