### PR TITLE
fix: use the canonical Hugging Face source for BGE-small

### DIFF
--- a/fastembed/text/onnx_embedding.py
+++ b/fastembed/text/onnx_embedding.py
@@ -77,7 +77,7 @@ supported_onnx_models: list[DenseModelDescription] = [
         ),
         license="mit",
         size_in_GB=0.067,
-        sources=ModelSource(hf="qdrant/bge-small-en-v1.5-onnx-q"),
+        sources=ModelSource(hf="Qdrant/bge-small-en-v1.5-onnx-Q"),
         model_file="model_optimized.onnx",
     ),
     DenseModelDescription(

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,16 +33,6 @@ def test_text_list_supported_models():
         assert "hf" in description["sources"] or "url" in description["sources"]
 
 
-def test_bge_small_canonical_huggingface_source():
-    description = next(
-        model
-        for model in TextEmbedding.list_supported_models()
-        if model["model"] == "BAAI/bge-small-en-v1.5"
-    )
-    # Avoid the case-normalizing redirect, which lacks X-Repo-Commit metadata.
-    assert description["sources"]["hf"] == "Qdrant/bge-small-en-v1.5-onnx-Q"
-
-
 def test_last_token_pooling():
     token_embeddings = np.array(
         [

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -33,6 +33,16 @@ def test_text_list_supported_models():
         assert "hf" in description["sources"] or "url" in description["sources"]
 
 
+def test_bge_small_canonical_huggingface_source():
+    description = next(
+        model
+        for model in TextEmbedding.list_supported_models()
+        if model["model"] == "BAAI/bge-small-en-v1.5"
+    )
+    # Avoid the case-normalizing redirect, which lacks X-Repo-Commit metadata.
+    assert description["sources"]["hf"] == "Qdrant/bge-small-en-v1.5-onnx-Q"
+
+
 def test_last_token_pooling():
     token_embeddings = np.array(
         [


### PR DESCRIPTION
Related to #706.

Use `Qdrant/bge-small-en-v1.5-onnx-Q` as the Hugging Face source for the existing `BAAI/bge-small-en-v1.5` model. The public model name, model file, dimensions, and inference settings are unchanged.

On September 8, I checked the initial HEAD responses for `config.json`:

- The currently registered lowercase source returns a 307 to the canonical repository path, without an `X-Repo-Commit` header.
- The canonical source returns a 307 to the Hub's resolve-cache endpoint, with `X-Repo-Commit` present.

This removes the extra case-normalizing redirect described in #706. It does not eliminate all redirects or change Hugging Face Hub's redirect handling. I did not reproduce the reporter's specific macOS/proxy/huggingface-hub 1.29.0 environment.

The regression test checks the source exposed by `TextEmbedding.list_supported_models()` and fails before the registry change. It is offline and does not download model weights.

Validation on Windows / Python 3.14.4, with huggingface-hub 1.30.0 and ONNX Runtime 1.29.0:

- `python -m pytest tests/test_common.py -q`: 4 passed.
- Ruff 0.3.4 lint and format checks on both changed files: passed.
- `git diff --check`: passed.
- A separate smoke test downloaded the model into a fresh cache and produced a finite 384-dimensional embedding. A subsequent `local_files_only=True` / `HF_HUB_OFFLINE=1` run succeeded from that cache.
- The full model test suite and the reporter's proxy setup were not tested.

Compatibility note: the Hugging Face repository ID is part of the cache directory name. Existing caches populated using the lowercase ID may need a one-time download into the canonical namespace; offline-only deployments should prepare that cache before upgrading. This patch does not migrate or delete old caches.

PR #593 addresses the analogous source correction for **BGE-base**, not BGE-small; this patch intentionally leaves that entry untouched.

Prepared with AI assistance; the checks and smoke tests above were executed locally. This is a model-source metadata fix, not a model or embedding-quality change.

### All Submissions

- [x] Followed the contributing guidelines.
- [x] Checked open and closed PRs for the same change at preparation time.
