### PR TITLE
docs: explain ONNX runtime and local-only loading options

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,49 @@ scores = list(model.rerank_pairs(
 ))
 ```
 
+## ⚙️ ONNX Runtime and local-only loading
+
+For ONNX-backed models, `threads` sets both the intra-op and inter-op thread counts for each ONNX Runtime session. `enable_cpu_mem_arena` is currently the only additional ONNX session option exposed by FastEmbed; set it to `False` to disable ONNX Runtime's CPU memory arena. Benchmark runtime settings with your workload.
+
+```python
+from fastembed import TextEmbedding
+
+model = TextEmbedding(
+    model_name="BAAI/bge-small-en-v1.5",
+    threads=4,
+    enable_cpu_mem_arena=False,
+)
+```
+
+To prepare a model for a later run without network access, first populate a known cache directory while online:
+
+```python
+from fastembed import TextEmbedding
+
+model_name = "BAAI/bge-small-en-v1.5"
+cache_dir = "./fastembed_cache"
+
+# This run may download the model into cache_dir.
+model = TextEmbedding(model_name=model_name, cache_dir=cache_dir)
+```
+
+A subsequent run can use the same model and cache without downloading files:
+
+```python
+from fastembed import TextEmbedding
+
+model_name = "BAAI/bge-small-en-v1.5"
+cache_dir = "./fastembed_cache"
+
+model = TextEmbedding(
+    model_name=model_name,
+    cache_dir=cache_dir,
+    local_files_only=True,
+)
+```
+
+If the required model files are missing from that cache, initialization with `local_files_only=True` raises a `ValueError` instead of downloading them.
+
 ## ⚡️ FastEmbed on a GPU
 
 FastEmbed supports running on GPU devices.


### PR DESCRIPTION
Documents how to configure ONNX session thread counts and `enable_cpu_mem_arena`, then populate a cache online and reuse it with `local_files_only=True`. It also explains the missing-cache error so offline deployments can be prepared correctly.

Addresses the runtime-options and local-only-loading parts of #579. Complements #638, which documents general cache configuration.

Validation: Python snippet syntax checks and `git diff --check` pass. A real-model check on Windows/Python 3.10.11 populated a fresh cache, reproduced identical embeddings in a fresh local-only process with Python socket/DNS calls blocked (zero attempts), verified the empty-cache ValueError, and confirmed both ONNX thread counts and the memory-arena setting. See the validation follow-up comment for versions and scope. Full repository tests were not run locally.

AI assistance was used to prepare and review this change.

### All Submissions:

* [x] Have you followed the guidelines in our Contributing document?
* [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
